### PR TITLE
Probstück 9

### DIFF
--- a/data/11/music-example1.mei
+++ b/data/11/music-example1.mei
@@ -112,7 +112,7 @@
                             </supplied>
                         </measure>
                         <measure n="5">
-                            <staff n="1" visible="true">
+                            <staff n="1">
                                 <layer n="1">
                                     <note dur="4" oct="5" pname="d" stem.dir="down" xml:id="ex-1769775861" />
                                     <beam>
@@ -128,7 +128,7 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff n="2" visible="true">
+                            <staff n="2">
                                 <layer n="3">
                                     <beam>
                                         <chord dur="8" stem.dir="up">
@@ -272,6 +272,18 @@
                                     </fb>
                                 </harm>
                             </supplied>
+                        </measure>
+                        <measure n="5" right="invis">
+                            <staff n="1">
+                                <layer n="1">
+                                    <custos oct="5" pname="c" />
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="2">
+                                    <custos oct="3" pname="b" />
+                                </layer>
+                            </staff>
                         </measure>
                     </section>
                 </score>

--- a/data/11/music-example1.mei
+++ b/data/11/music-example1.mei
@@ -98,23 +98,25 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="2" tstamp="1">
-                                <fb>
-                                    <f>5</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
+                            <supplied resp="#pfeffer">
+                                <harm place="above" staff="2" tstamp="1">
+                                    <fb>
+                                        <f>5</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="2">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                         <measure n="5">
                             <staff n="1" visible="true">
                                 <layer n="1">
-                                    <note dur="4" oct="5" pname="d" stem.dir="down" />
+                                    <note dur="4" oct="5" pname="d" stem.dir="down" xml:id="ex-1769775861" />
                                     <beam>
-                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" xml:id="ex-1881082125" />
                                         <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
                                         <note dur="16" oct="5" pname="f" stem.dir="down" />
                                         <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
@@ -174,24 +176,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000000810903591" startid="#note-0000001769775861" endid="#note-0000001881082125" />
-                            <harm place="above" staff="2" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
+                            <tie startid="#ex-1769775861" endid="#ex-1881082125" />
+                            <supplied resp="#pfeffer">
+                                <harm place="above" staff="2" tstamp="1">
+                                    <fb>
+                                        <f>7</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="2">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                         <measure n="6">
                             <staff n="1">
                                 <layer n="1">
-                                    <note dur="4" oct="5" pname="c" stem.dir="down" />
+                                    <note dur="4" oct="5" pname="c" stem.dir="down" xml:id="ex-1193092165" />
                                     <beam>
-                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" xml:id="ex-0802666718" />
                                         <note dur="16" oct="5" pname="d" stem.dir="down" />
                                         <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
                                         <note dur="16" oct="5" pname="d" stem.dir="down" />
@@ -200,7 +204,7 @@
                                         <note dur="8" oct="5" pname="c" stem.dir="down" />
                                         <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
                                         <note dur="16" oct="4" pname="a" stem.dir="up">
-                                            <accid xml:id="accid-0000000172708545" accid="n" />
+                                            <accid accid="n" />
                                         </note>
                                     </beam>
                                 </layer>
@@ -220,8 +224,8 @@
                                     <beam>
                                         <chord dur="8" stem.dir="up">
                                             <note oct="4" pname="e" accid.ges="f" />
-                                            <note oct="4" pname="a" color="#000000">
-                                                <accid xml:id="accid-0000000245173094" accid="n" />
+                                            <note oct="4" pname="a">
+                                                <accid accid="n" />
                                             </note>
                                         </chord>
                                         <chord dur="8" stem.dir="up">
@@ -255,17 +259,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <tie xml:id="tie-0000001515009327" startid="#note-0000001193092165" endid="#note-0000000802666718" />
-                            <harm place="above" staff="2" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="2">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
+                            <tie startid="#ex-1193092165" endid="#ex-0802666718" />
+                            <supplied resp="#pfeffer">
+                                <harm place="above" staff="2" tstamp="1">
+                                    <fb>
+                                        <f>7</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="2">
+                                    <fb>
+                                        <f>6⃥</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                     </section>
                 </score>

--- a/data/11/music-example1.mei
+++ b/data/11/music-example1.mei
@@ -28,8 +28,8 @@
                 <score>
                     <scoreDef mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
-                            <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
+                            <staffDef clef.shape="G" clef.line="2" key.sig="3f" n="1" lines="5" />
+                            <staffDef clef.shape="C" clef.line="3" key.sig="3f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>

--- a/data/11/music-example1.mei
+++ b/data/11/music-example1.mei
@@ -29,7 +29,7 @@
             <mdiv>
                 <score>
                     <scoreDef>
-                        <staffGrp>
+                        <staffGrp mnum.visible="false">
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
                         </staffGrp>

--- a/data/11/music-example1.mei
+++ b/data/11/music-example1.mei
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title></title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -23,240 +22,251 @@
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
-                        <staffGrp mnum.visible="false">
+                    <scoreDef mnum.visible="false">
+                        <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
-                      <measure n="4">
-                          <staff n="1">
-                              <layer n="1">
-                                  <rest dur="4" />
-                                  <rest dur="16" />
-                                  <beam>
-                                    <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="g" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                    <note dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                    <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2">
-                              <layer n="3">
-                                  <beam xml:id="beam-0000002015005583">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="g" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="g" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                  </beam>
-                                  <beam xml:id="beam-0000000278990011">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="g" />
-                                          <note oct="5" pname="c" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="g" />
-                                          <note oct="5" pname="c" />
-                                      </chord>
-                                  </beam>
-                                  <beam xml:id="beam-0000000829690062">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="g" />
-                                          <note oct="5" pname="c" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="g" />
-                                          <note oct="5" pname="c" />
-                                      </chord>
-                                  </beam>
-                              </layer>
-                              <layer n="2">
-                                  <beam xml:id="beam-0000001620104056">
-                                      <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                      <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <beam xml:id="beam-0000001858429545">
-                                      <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                      <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <beam xml:id="beam-0000001212274491">
-                                      <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                      <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <harm place='above' staff="2" tstamp="1"><fb>
-                              <f>5</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                      </measure>
-                      <measure n="5">
-                          <staff n="1" visible="true">
-                              <layer n="1">
-                                  <note dur="4" oct="5" pname="d" stem.dir="down" />
-                                  <beam>
-                                    <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                    <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <beam>
-                                    <note dur="8" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2" visible="true">
-                              <layer n="3">
-                                  <beam xml:id="beam-0000001992178321">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="f" />
-                                          <note oct="5" pname="c" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="f" />
-                                          <note oct="5" pname="c" />
-                                      </chord>
-                                  </beam>
-                                  <beam xml:id="beam-0000001083662410">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="f" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="f" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                  </beam>
-                                  <beam xml:id="beam-0000002044080682">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="f" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="f" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                  </beam>
-                              </layer>
-                              <layer n="2">
-                                  <beam xml:id="beam-0000000333915297">
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                  </beam>
-                                  <beam xml:id="beam-0000001599189144">
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                  </beam>
-                                  <beam xml:id="beam-0000000295139712">
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <tie xml:id="tie-0000000810903591" startid="#note-0000001769775861" endid="#note-0000001881082125" />
-                          <harm place='above' staff="2" tstamp="1"><fb>
-                              <f>7</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                      </measure>
-                      <measure n="6">
-                          <staff n="1">
-                              <layer n="1">
-                                  <note dur="4" oct="5" pname="c" stem.dir="down" />
-                                  <beam>
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                    <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                    <note dur="8" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                    <note dur="16" oct="4" pname="a" stem.dir="up">
-                                        <accid xml:id="accid-0000000172708545" accid="n" />
-                                    </note>
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2">
-                              <layer n="3">
-                                  <beam xml:id="beam-0000000860823091">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="e" accid.ges="f" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="e" accid.ges="f" />
-                                          <note oct="4" pname="b" accid.ges="f" />
-                                      </chord>
-                                  </beam>
-                                  <beam xml:id="beam-0000001060964278">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="e" accid.ges="f" />
-                                          <note oct="4" pname="a" color="#000000">
-                                              <accid xml:id="accid-0000000245173094" accid="n" />
-                                          </note>
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="e" accid.ges="f" />
-                                          <note oct="4" pname="a" />
-                                      </chord>
-                                  </beam>
-                                  <beam xml:id="beam-0000001606815751">
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="e" accid.ges="f" />
-                                          <note oct="4" pname="a" />
-                                      </chord>
-                                      <chord dur="8" stem.dir="up">
-                                          <note oct="4" pname="e" accid.ges="f" />
-                                          <note oct="4" pname="a" />
-                                      </chord>
-                                  </beam>
-                              </layer>
-                              <layer n="2">
-                                  <beam xml:id="beam-0000000740351594">
-                                      <note dur="8" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="8" oct="4" pname="c" stem.dir="down" />
-                                  </beam>
-                                  <beam xml:id="beam-0000001144542136">
-                                      <note dur="8" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="8" oct="4" pname="c" stem.dir="down" />
-                                  </beam>
-                                  <beam xml:id="beam-0000001199784798">
-                                      <note dur="8" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="8" oct="4" pname="c" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <tie xml:id="tie-0000001515009327" startid="#note-0000001193092165" endid="#note-0000000802666718" />
-                          <harm place='above' staff="2" tstamp="1"><fb>
-                              <f>7</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6⃥</f>
-                          </fb></harm>
-                      </measure>
+                        <measure n="4">
+                            <staff n="1">
+                                <layer n="1">
+                                    <rest dur="4" />
+                                    <rest dur="16" />
+                                    <beam>
+                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="g" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="3">
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="g" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="g" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                    </beam>
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="g" />
+                                            <note oct="5" pname="c" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="g" />
+                                            <note oct="5" pname="c" />
+                                        </chord>
+                                    </beam>
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="g" />
+                                            <note oct="5" pname="c" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="g" />
+                                            <note oct="5" pname="c" />
+                                        </chord>
+                                    </beam>
+                                </layer>
+                                <layer n="2">
+                                    <beam>
+                                        <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                        </measure>
+                        <measure n="5">
+                            <staff n="1" visible="true">
+                                <layer n="1">
+                                    <note dur="4" oct="5" pname="d" stem.dir="down" />
+                                    <beam>
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2" visible="true">
+                                <layer n="3">
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="f" />
+                                            <note oct="5" pname="c" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="f" />
+                                            <note oct="5" pname="c" />
+                                        </chord>
+                                    </beam>
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="f" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="f" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                    </beam>
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="f" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="f" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                    </beam>
+                                </layer>
+                                <layer n="2">
+                                    <beam>
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <tie xml:id="tie-0000000810903591" startid="#note-0000001769775861" endid="#note-0000001881082125" />
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                        </measure>
+                        <measure n="6">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note dur="4" oct="5" pname="c" stem.dir="down" />
+                                    <beam>
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="a" stem.dir="up">
+                                            <accid xml:id="accid-0000000172708545" accid="n" />
+                                        </note>
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="3">
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="e" accid.ges="f" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="e" accid.ges="f" />
+                                            <note oct="4" pname="b" accid.ges="f" />
+                                        </chord>
+                                    </beam>
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="e" accid.ges="f" />
+                                            <note oct="4" pname="a" color="#000000">
+                                                <accid xml:id="accid-0000000245173094" accid="n" />
+                                            </note>
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="e" accid.ges="f" />
+                                            <note oct="4" pname="a" />
+                                        </chord>
+                                    </beam>
+                                    <beam>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="e" accid.ges="f" />
+                                            <note oct="4" pname="a" />
+                                        </chord>
+                                        <chord dur="8" stem.dir="up">
+                                            <note oct="4" pname="e" accid.ges="f" />
+                                            <note oct="4" pname="a" />
+                                        </chord>
+                                    </beam>
+                                </layer>
+                                <layer n="2">
+                                    <beam>
+                                        <note dur="8" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="8" oct="4" pname="c" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="8" oct="4" pname="c" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="8" oct="4" pname="c" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <tie xml:id="tie-0000001515009327" startid="#note-0000001193092165" endid="#note-0000000802666718" />
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                        </measure>
                     </section>
                 </score>
             </mdiv>

--- a/data/11/music-example2.mei
+++ b/data/11/music-example2.mei
@@ -23,13 +23,12 @@
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
                     <scoreDef>
-                        <staffGrp>
+                        <staffGrp mnum.visible="false">
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
                         </staffGrp>

--- a/data/11/music-example2.mei
+++ b/data/11/music-example2.mei
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title></title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -27,127 +26,139 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
-                        <staffGrp mnum.visible="false">
+                    <scoreDef mnum.visible="false">
+                        <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
-                      <measure n="23">
-                          <staff n="1" visible="true">
-                              <layer n="1">
-                                  <rest dur="16" />
-                                  <beam>
-                                    <note dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" />
-                                    <note dur="16" oct="3" pname="g" stem.dir="up" />
-                                    <note dur="16" oct="4" pname="c" stem.dir="up" />
-                                  </beam>
-                                  <beam>
-                                    <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
-                                    <note dur="16" oct="4" pname="g" stem.dir="up" />
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <beam>
-                                    <note dur="8" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="4" pname="b" stem.dir="down">
-                                        <accid accid="n" />
-                                    </note>
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2" visible="true">
-                              <layer n="1">
-                                  <clef shape="F" line="4" />
-                                  <beam xml:id="beam-0000001296114855">
-                                      <note dur="16" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="16" oct="2" pname="g" stem.dir="down" />
-                                      <note dur="16" oct="3" pname="c" stem.dir="down" />
-                                      <note dur="16" oct="3" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <clef shape="C" line="4" />
-                                  <beam xml:id="beam-0000000193428611">
-                                      <note dur="16" oct="3" pname="g" stem.dir="down" />
-                                      <note dur="16" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                      <note dur="16" oct="4" pname="g" stem.dir="down" />
-                                  </beam>
-                                  <beam xml:id="beam-0000000009604777">
-                                      <note dur="8" oct="4" pname="f" stem.dir="down" />
-                                      <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                      <note dur="16" oct="4" pname="d" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                              <f>4</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="3"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="3.500000" vgrp="80"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="3.750000" vgrp="80"><fb>
-                              <f>6⃥</f>
-                          </fb></harm>
-                      </measure>
-                      <measure n="24">
-                          <staff n="1">
-                              <layer n="1">
-                                <beam>
-                                  <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="16" oct="3" pname="g" stem.dir="up" />
-                                  <note dur="16" oct="4" pname="c" stem.dir="up" />
-                                  <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
-                                </beam>
-                                <beam>
-                                  <note dur="16" oct="4" pname="g" stem.dir="up" />
-                                  <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  <note dur="16" oct="5" pname="g" stem.dir="down" />
-                                </beam>
-                                <beam>
-                                  <note dur="8" oct="5" pname="f" stem.dir="down" />
-                                  <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2">
-                              <layer n="1">
-                                  <beam xml:id="beam-0000001785130956">
-                                      <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
-                                      <clef shape="F" line="4" />
-                                      <note dur="16" oct="2" pname="e" stem.dir="up" accid.ges="f" />
-                                      <note dur="16" oct="2" pname="g" stem.dir="up" />
-                                      <note dur="16" oct="3" pname="c" stem.dir="up" />
-                                  </beam>
-                                  <beam xml:id="beam-0000002112509382">
-                                      <note dur="16" oct="3" pname="e" stem.dir="down" accid.ges="f" />
-                                      <note dur="16" oct="3" pname="g" stem.dir="down" />
-                                      <note dur="16" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <beam xml:id="beam-0000001071651313">
-                                      <note dur="8" oct="4" pname="d" stem.dir="down" />
-                                      <note dur="16" oct="4" pname="c" stem.dir="down" />
-                                      <note dur="16" oct="3" pname="b" stem.dir="down">
-                                          <accid accid="n" />
-                                      </note>
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="3"><fb>
-                              <f>6⃥</f>
-                          </fb></harm>
-                      </measure>
+                        <measure n="23">
+                            <staff n="1">
+                                <layer n="1">
+                                    <rest dur="16" />
+                                    <beam>
+                                        <note dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" />
+                                        <note dur="16" oct="3" pname="g" stem.dir="up" />
+                                        <note dur="16" oct="4" pname="c" stem.dir="up" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="g" stem.dir="up" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="b" stem.dir="down">
+                                            <accid accid="n" />
+                                        </note>
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="1">
+                                    <clef shape="F" line="4" />
+                                    <beam>
+                                        <note dur="16" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="2" pname="g" stem.dir="down" />
+                                        <note dur="16" oct="3" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="3" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <clef shape="C" line="4" />
+                                    <beam>
+                                        <note dur="16" oct="3" pname="g" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="g" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="f" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="d" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.500000" vgrp="80">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.750000" vgrp="80">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                        </measure>
+                        <measure n="24">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="3" pname="g" stem.dir="up" />
+                                        <note dur="16" oct="4" pname="c" stem.dir="up" />
+                                        <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="4" pname="g" stem.dir="up" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
+                                        <clef shape="F" line="4" />
+                                        <note dur="16" oct="2" pname="e" stem.dir="up" accid.ges="f" />
+                                        <note dur="16" oct="2" pname="g" stem.dir="up" />
+                                        <note dur="16" oct="3" pname="c" stem.dir="up" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="3" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="3" pname="g" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="4" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="3" pname="b" stem.dir="down">
+                                            <accid accid="n" />
+                                        </note>
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                        </measure>
                     </section>
                 </score>
             </mdiv>

--- a/data/11/music-example2.mei
+++ b/data/11/music-example2.mei
@@ -79,27 +79,29 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="2" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                    <f>4</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="3.500000" vgrp="80">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="3.750000" vgrp="80">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
+                            <supplied resp="#pfeffer">
+                                <harm place="above" staff="2" tstamp="2">
+                                    <fb>
+                                        <f>6</f>
+                                        <f>4</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="3">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="3.5">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="3.75">
+                                    <fb>
+                                        <f>6⃥</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                         <measure n="24">
                             <staff n="1">
@@ -147,16 +149,18 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="2" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="2" tstamp="3">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
+                            <supplied resp="#pfeffer">
+                                <harm place="above" staff="2" tstamp="2">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="2" tstamp="3">
+                                    <fb>
+                                        <f>6⃥</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                     </section>
                 </score>

--- a/data/11/music-example2.mei
+++ b/data/11/music-example2.mei
@@ -36,10 +36,10 @@
                         <measure n="23">
                             <staff n="1">
                                 <layer n="1">
-                                    <rest dur="16" />
+                                    <rest dur="16" staff="2" loc="6" />
                                     <beam>
-                                        <note dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" />
-                                        <note dur="16" oct="3" pname="g" stem.dir="up" />
+                                        <note dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" staff="2" />
+                                        <note dur="16" oct="3" pname="g" stem.dir="up" staff="2" />
                                         <note dur="16" oct="4" pname="c" stem.dir="up" />
                                     </beam>
                                     <beam>
@@ -59,9 +59,8 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <clef shape="F" line="4" />
+                                    <rest dur="16" loc="0" />
                                     <beam>
-                                        <note dur="16" oct="4" pname="c" stem.dir="down" />
                                         <note dur="16" oct="2" pname="g" stem.dir="down" />
                                         <note dur="16" oct="3" pname="c" stem.dir="down" />
                                         <note dur="16" oct="3" pname="e" stem.dir="down" accid.ges="f" />
@@ -126,10 +125,10 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
+                                    <clef shape="F" line="4" />
                                     <beam>
-                                        <note dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
-                                        <clef shape="F" line="4" />
-                                        <note dur="16" oct="2" pname="e" stem.dir="up" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="2" pname="e" stem.dir="up" accid.ges="f" staff="2" />
                                         <note dur="16" oct="2" pname="g" stem.dir="up" />
                                         <note dur="16" oct="3" pname="c" stem.dir="up" />
                                     </beam>

--- a/data/11/music-example3.mei
+++ b/data/11/music-example3.mei
@@ -70,7 +70,9 @@
                                     <beam>
                                         <note dur="32" oct="4" pname="g" stem.dir="up" />
                                         <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                        <note dur="32" oct="5" pname="e" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="e" stem.dir="down">
+                                            <accid accid="n" />
+                                        </note>
                                         <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
                                     </beam>
                                 </layer>

--- a/data/11/music-example3.mei
+++ b/data/11/music-example3.mei
@@ -23,13 +23,12 @@
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
                     <scoreDef>
-                        <staffGrp>
+                        <staffGrp mnum.visible="false">
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                         </staffGrp>
                     </scoreDef>

--- a/data/11/music-example3.mei
+++ b/data/11/music-example3.mei
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title></title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -27,56 +26,56 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
-                        <staffGrp mnum.visible="false">
+                    <scoreDef mnum.visible="false">
+                        <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
-                      <measure n="33">
-                          <staff n="1">
-                              <layer n="1">
-                                <beam>
-                                  <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="f" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                </beam>
-                                <beam>
-                                  <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="f" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                </beam>
-                                <beam>
-                                  <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="f" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                </beam>
-                                <beam>
-                                  <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="f" stem.dir="down" />
-                                  <note dur="32" oct="5" pname="c" stem.dir="down" />
-                                </beam>
-                                <beam>
-                                  <note dur="32" oct="4" pname="g" stem.dir="up" />
-                                  <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                  <note dur="32" oct="5" pname="e" stem.dir="down">
-                                      <accid accid="n" />
-                                  </note>
-                                  <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                </beam>
-                                <beam>
-                                  <note dur="32" oct="4" pname="g" stem.dir="up" />
-                                  <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                  <note dur="32" oct="5" pname="e" stem.dir="down" />
-                                  <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                </beam>
-                              </layer>
-                          </staff>
-                      </measure>
+                        <measure n="33">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="32" oct="4" pname="a" stem.dir="up" accid.ges="f" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="32" oct="4" pname="g" stem.dir="up" />
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                        <note dur="32" oct="5" pname="e" stem.dir="down">
+                                            <accid accid="n" />
+                                        </note>
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="32" oct="4" pname="g" stem.dir="up" />
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                        <note dur="32" oct="5" pname="e" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
                     </section>
                 </score>
             </mdiv>

--- a/data/11/music-example4.mei
+++ b/data/11/music-example4.mei
@@ -23,13 +23,12 @@
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
                     <scoreDef>
-                        <staffGrp>
+                        <staffGrp mnum.visible="false">
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
                         </staffGrp>

--- a/data/11/music-example4.mei
+++ b/data/11/music-example4.mei
@@ -36,7 +36,9 @@
                         <measure n="54">
                             <staff n="1">
                                 <layer n="1">
-                                    <space dur="4" />
+                                    <supplied resp="#pfeffer">
+                                        <space dur="4" />
+                                    </supplied>
                                     <rest dur="8" />
                                     <note dur="8" oct="5" pname="f" stem.dir="down" />
                                     <beam>
@@ -49,7 +51,9 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <space dur="4" />
+                                    <supplied resp="#pfeffer">
+                                        <space dur="4" />
+                                    </supplied>
                                     <beam>
                                         <note dur="8" oct="3" pname="a" stem.dir="down">
                                             <accid accid="n" />

--- a/data/11/music-example4.mei
+++ b/data/11/music-example4.mei
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title></title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -27,136 +26,150 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
-                        <staffGrp mnum.visible="false">
+                    <scoreDef mnum.visible="false">
+                        <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" key.sig="3f" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" key.sig="3f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
-                      <measure n="54">
-                          <staff n="1">
-                              <layer n="1">
-                                  <space dur="4" />
-                                  <rest dur="8" />
-                                  <note dur="8" oct="5" pname="f" stem.dir="down" />
-                                  <beam>
-                                    <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2">
-                              <layer n="1">
-                                  <space dur="4" />
-                                  <beam>
-                                      <note dur="8" oct="3" pname="a" stem.dir="down">
-                                          <accid accid="n" />
-                                      </note>
-                                      <note dur="8" oct="3" pname="a" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                      <note dur="8" oct="3" pname="a" stem.dir="down" />
-                                      <note dur="8" oct="3" pname="a" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                      </measure>
-                      <measure n="55">
-                          <staff n="1">
-                              <layer n="1">
-                                <beam>
-                                  <note dur="8" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                  <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                </beam>
-                                <beam>
-                                  <note dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  <note dur="16" oct="5" pname="g" stem.dir="down" />
-                                  <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                </beam>
-                                <beam>
-                                  <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                  <note dur="16" oct="4" pname="a" stem.dir="up">
-                                      <accid accid="n" />
-                                  </note>
-                                </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2">
-                              <layer n="1">
-                                  <beam>
-                                      <note dur="8" oct="3" pname="a" stem.dir="down">
-                                          <accid accid="n" />
-                                      </note>
-                                      <note dur="8" oct="3" pname="g" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                      <note dur="8" oct="3" pname="g" stem.dir="down" />
-                                      <note dur="8" oct="3" pname="g" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                      <note dur="8" oct="3" pname="g" stem.dir="down" />
-                                      <note dur="8" oct="3" pname="g" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <harm place='above' staff="2" tstamp="1"><fb>
-                              <f>2</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                      </measure>
-                      <measure n="56">
-                          <staff n="1">
-                              <layer n="1">
-                                  <note dur="8" oct="4" pname="a" stem.dir="up">
-                                      <accid accid="n" />
-                                  </note>
-                                  <note dur="4" oct="5" pname="d" stem.dir="down" />
-                                  <beam>
-                                    <note dur="16" oct="5" pname="f" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
-                                  </beam>
-                                  <beam>
-                                    <note dur="16" oct="5" pname="d" stem.dir="down" />
-                                    <note dur="16" oct="5" pname="c" stem.dir="down" />
-                                    <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
-                                    <note dur="16" oct="4" pname="a" stem.dir="up" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <staff n="2">
-                              <layer n="1">
-                                  <beam>
-                                      <note dur="8" oct="3" pname="g" stem.dir="down" />
-                                      <note dur="8" oct="3" pname="f" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                      <note dur="8" oct="3" pname="f" stem.dir="down" />
-                                      <note dur="8" oct="3" pname="f" stem.dir="down" />
-                                  </beam>
-                                  <beam>
-                                      <note dur="8" oct="3" pname="f" stem.dir="down" />
-                                      <note dur="8" oct="3" pname="f" stem.dir="down" />
-                                  </beam>
-                              </layer>
-                          </staff>
-                          <harm place='above' staff="2" tstamp="1"><fb>
-                              <f>2♮</f>
-                          </fb></harm>
-                          <harm place='above' staff="2" tstamp="2"><fb>
-                              <f>6</f>
-                          </fb></harm>
-                      </measure>
+                        <measure n="54">
+                            <staff n="1">
+                                <layer n="1">
+                                    <space dur="4" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="5" pname="f" stem.dir="down" />
+                                    <beam>
+                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="1">
+                                    <space dur="4" />
+                                    <beam>
+                                        <note dur="8" oct="3" pname="a" stem.dir="down">
+                                            <accid accid="n" />
+                                        </note>
+                                        <note dur="8" oct="3" pname="a" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="3" pname="a" stem.dir="down" />
+                                        <note dur="8" oct="3" pname="a" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                        </measure>
+                        <measure n="55">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="8" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="g" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="a" stem.dir="up">
+                                            <accid accid="n" />
+                                        </note>
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="8" oct="3" pname="a" stem.dir="down">
+                                            <reg resp="#rettinghaus">
+                                                <accid accid="n" enclose="brack" />
+                                            </reg>
+                                        </note>
+                                        <note dur="8" oct="3" pname="g" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="3" pname="g" stem.dir="down" />
+                                        <note dur="8" oct="3" pname="g" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="3" pname="g" stem.dir="down" />
+                                        <note dur="8" oct="3" pname="g" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>2</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                        </measure>
+                        <measure n="56">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note dur="8" oct="4" pname="a" stem.dir="up">
+                                        <reg resp="#rettinghaus">
+                                            <accid accid="n" enclose="brack" />
+                                        </reg>
+                                    </note>
+                                    <note dur="4" oct="5" pname="d" stem.dir="down" />
+                                    <beam>
+                                        <note dur="16" oct="5" pname="f" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="e" stem.dir="down" accid.ges="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="16" oct="5" pname="c" stem.dir="down" />
+                                        <note dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f" />
+                                        <note dur="16" oct="4" pname="a" stem.dir="up" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <staff n="2">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="8" oct="3" pname="g" stem.dir="down" />
+                                        <note dur="8" oct="3" pname="f" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="3" pname="f" stem.dir="down" />
+                                        <note dur="8" oct="3" pname="f" stem.dir="down" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="8" oct="3" pname="f" stem.dir="down" />
+                                        <note dur="8" oct="3" pname="f" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>2♮</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                        </measure>
                     </section>
                 </score>
             </mdiv>

--- a/data/13/music-example1.mei
+++ b/data/13/music-example1.mei
@@ -30,7 +30,7 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="2f">
+                    <scoreDef key.sig="2f" mnum.visible="false">
                         <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" n="2" lines="5" />

--- a/data/13/music-example2.mei
+++ b/data/13/music-example2.mei
@@ -30,7 +30,7 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="2f">
+                    <scoreDef key.sig="2f" mnum.visible="false">
                         <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" n="1" lines="5" />
                         </staffGrp>

--- a/data/13/music-example3.mei
+++ b/data/13/music-example3.mei
@@ -30,7 +30,7 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="1f">
+                    <scoreDef key.sig="1f" mnum.visible="false">
                         <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" n="2" lines="5" />

--- a/data/13/music-example3.mei
+++ b/data/13/music-example3.mei
@@ -15,30 +15,26 @@
                 </respStmt>
             </titleStmt>
             <editionStmt>
-                <edition>
-                    First draft,
-                    <date>2019</date>
-                </edition>
+                <edition>First draft, <date>2019</date></edition>
             </editionStmt>
             <pubStmt>
                 <unpub />
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="1f" mnum.visible="false">
+                    <scoreDef mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" />
-                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5" />
+                            <staffDef clef.shape="C" clef.line="1" key.sig="1f" n="1" lines="5" />
+                            <staffDef clef.shape="F" clef.line="4" key.sig="1f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <measure n="1">
-                            <staff n="1" visible="true">
+                            <staff n="1">
                                 <layer n="1">
                                     <beam>
                                         <note dur="16" oct="4" pname="g" stem.dir="up" />
@@ -57,7 +53,7 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <staff n="2" visible="true">
+                            <staff n="2">
                                 <layer n="1">
                                     <beam>
                                         <note dots="1" dur="8" oct="3" pname="c" stem.dir="up" />

--- a/data/13/music-example4.mei
+++ b/data/13/music-example4.mei
@@ -368,7 +368,7 @@
                                         <note oct="5" pname="f" />
                                         <note oct="5" pname="b" accid.ges="f" />
                                     </chord>
-                                    <space dur="8" />
+                                    <rest dots="1" dur="8" />
                                 </layer>
                             </staff>
                             <staff n="2">
@@ -377,7 +377,6 @@
                                     <rest dots="1" dur="8" />
                                 </layer>
                             </staff>
-                            <tie startid="#note-0000001533412361" endid="#note-0000000360421828" />
                         </measure>
                     </section>
                 </score>

--- a/data/13/music-example4.mei
+++ b/data/13/music-example4.mei
@@ -29,7 +29,7 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef key.sig="2f">
+                    <scoreDef key.sig="2f" mnum.visible="false">
                         <staffGrp>
                             <staffDef clef.shape="C" clef.line="1" n="1" lines="5" />
                             <staffDef clef.shape="F" clef.line="4" n="2" lines="5" />

--- a/data/14/music-example1.mei
+++ b/data/14/music-example1.mei
@@ -30,7 +30,7 @@
             <mdiv>
                 <score>
                     <scoreDef>
-                        <staffGrp>
+                        <staffGrp mnum.visible="false">
                             <staffDef clef.shape="C" clef.line="1" key.sig="5f" n="1" lines="5" label="Mattheson's annotations" />
                         </staffGrp>
                     </scoreDef>

--- a/data/9/annotations_de.tei
+++ b/data/9/annotations_de.tei
@@ -43,24 +43,24 @@
             einmahl gesagt) muß nothwendig geschehen, wenn etwas in seiner Vollkommenheit
             gebracht werden soll; und wer den Sinn des Verfassers nicht erräth oder
             trifft, der fehlet weit, ob ers auch am besten sonst getroffen zu haben
-            meynen solte. Wenn man demnach im <ref target="#m-210">siebenden Tact</ref> den Schluß gemacht
+            meynen solte. Wenn man demnach im <ref target="#m-243">siebenden Tact</ref> den Schluß gemacht
             hat, so muß gleich die rechte Hand etwas mehrers, als die kahlen Accorte
             und Sexten, dazu spielen, denn solche kann die lincke wol allein verrichten;
-            nun findet sich aber ehender kein Gegen-Satz als im <ref target="#m-640">zwantzigstes Tact</ref>,
+            nun findet sich aber ehender kein Gegen-Satz als im <ref target="#m-668">zwantzigstes Tact</ref>,
             derselbe muß hier beym <hi rendition="#b">c</hi> mit der Tertz anfangen,
             und immer einen Ton höher, viermahl wiederholet werden. Woraus denn leicht
-            zu schliessen, daß nachgehends, im <ref target="#m-402">dreizehenden Tact</ref>, dergleichen abermahl
+            zu schliessen, daß nachgehends, im <ref target="#m-436">dreizehenden Tact</ref>, dergleichen abermahl
             erfordert werde, da jedoch nicht mit der Tertz, sondern beym <hi rendition="#b">g</hi>
             mit der Octave angefangen, auch der Lauff, wie vorhin, viermahl, jedes mahl
-            um einen Ton höher, wiederholet wird. Im <ref target="#m-640">zwantzigsten Tact</ref> erscheinet
+            um einen Ton höher, wiederholet wird. Im <ref target="#m-668">zwantzigsten Tact</ref> erscheinet
             der bisherige Gegen-Satz im Basse, einfolglich kann man das Ding umkehren
             und den Gang, welchen vorhin der Baß gehabt, im Discant gebrauchen,
             wobey die Griffe gantz wol vollstimmig bleiben können. Wenns zur
-            letzten Helffte des <ref target="#m-701">zwey und zwantzigsten Tacts</ref> kommt, da drey Viertel
+            letzten Helffte des <ref target="#m-742">zwey und zwantzigsten Tacts</ref> kommt, da drey Viertel
             stehen, thut man wol, mit der rechten Hand vom dreigestrichenen
             <hi rendition="#b">c</hi> zur Nachahmung ins zweigestrichene <hi rendition="#b">d</hi> herunter
-            zu lauffen; doch dabey die 6 und 5 im Baß unvergessen. Der <ref target="#m-781">vier und zwantzigste
-            Tact</ref> wechselt abermahl mit beiden Sätzen ab; und im <ref target="#m-1014">zwey und dreyßigsten</ref>
+            zu lauffen; doch dabey die 6 und 5 im Baß unvergessen. <ref target="#m-809">Der vier und zwantzigste
+            Tact</ref> wechselt abermahl mit beiden Sätzen ab; und im <ref target="#m-1044">zwey und dreyßigsten</ref>
             mag man mit Tertzen lauffen, bey den drey Vierteln aber das itzt
             berührte Nachahmungs-Clausulgen anbringen. Ich besorge zwar, die
             musicalischen Gesetzgeber werden mir einen Proceß an den Hals werffen,
@@ -71,7 +71,8 @@
         <div n="2" type="section">
           <head>§. 2.</head>
           <p xml:id="p2-1" facs="#facsZone-p2-1">
-            Der <ref target="#m-1187">sieben und dreißigste Tact</ref> will, nebst den folgenden, eine besondere,
+            <ref target="#m-1220">Der sieben und dreißigste Tact</ref> will,
+            <ref target="#m-1253 #m-1295 #m-1334">nebst den folgenden</ref>, eine besondere,
             wiewol aus den vorhergehenden zunehmende Brechung haben, wobey die
             überstehende Ziefern alle gantz genau mit zunehmen sind. Da
             solches aber einem jeden etwas schwer zu errathen fallen mögte, will

--- a/data/9/annotations_en.tei
+++ b/data/9/annotations_en.tei
@@ -23,18 +23,18 @@
           Various things will need to be reminded of, if one wants to play the thing according to the author's liking.
           This – it shall be said once again – necessarily has to happen, if anything should be brought to perfection. Somebody who does not
           catch or divine the author's intention, misses it by far, even if he thinks to have found it.
-          When having played the cadence in the <ref target="#m-210">seventh measure</ref>, the right hand has to play right away something more
+          When having played the cadence in the <ref target="#m-243">seventh measure</ref>, the right hand has to play right away something more
           than the bald chords and sixths, for this can be done by the left hand alone.
-          No counter-melody can now be found prior to the <ref target="#m-640">20th measure</ref>,
+          No counter-melody can now be found prior to the <ref target="#m-668">20th measure</ref>,
           which has to be taken here and begins on the <hi rendition="#b">c</hi> with the third,
           and will be repeated four times, always one tone higher. One can easily conclude that afterwards,
-          <ref target="#m-402">in measure 13</ref> the same is required once more, however, not with the third, but starting
+          <ref target="#m-436">in measure 13</ref> the same is required once more, however, not with the third, but starting
           with the octave on the <hi rendition="#b">g</hi> the progression is repeated four times, always one tone higher, just as before.
-          In <ref target="#m-640">measure 20</ref> the previous counter-melody shows up in the bass, so the thing can be
+          In <ref target="#m-668">measure 20</ref> the previous counter-melody shows up in the bass, so the thing can be
           turned around and the melody that was before in the bass can now be used in the discant while still playing
-          full-voiced chords. When it appears in the last half of the <ref target="#m-701">22nd measure</ref>, where three crotchets
+          full-voiced chords. When it appears in the last half of the <ref target="#m-742">22nd measure</ref>, where three crotchets
           are, one does well to descent from C3 down to D2 in order to imitate; but not forgetting the 6 and 5 in the bass.
-          The <ref target="#m-781">24th measure</ref> alternates again the motives and in the <ref target="#m-1014">32nd</ref>
+          The <ref target="#m-809">24th measure</ref> alternates again the motives and in the <ref target="#m-1044">32nd</ref>
           one may play scales in thirds, and where the three crotchets are, one plays the just mentioned small imitation clause.
           I am afraid that the musical lawmakers will throw a lawsuit at me for using the C3 in thorough bass.
           But my defense is already done.
@@ -43,7 +43,7 @@
       <div n="2" type="section">
         <head>§. 2.</head>
         <p xml:id="p2-1">
-          The <ref target="#m-1187">37th measure</ref> and the following ones need a special and more intense kind of arpeggiation
+          <ref target="#m-1220">The 37th measure</ref> and <ref target="#m-1253 #m-1295 #m-1334">the following ones</ref> need a special and more intense kind of arpeggiation
           while playing exactly the figures placed above.
           Since it might be hard to guess I will write down a bit of it for the beginners:
           <notatedMusic xml:id="music-example1">

--- a/data/9/music-example1.mei
+++ b/data/9/music-example1.mei
@@ -28,14 +28,22 @@
                 <score>
                     <scoreDef mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5" />
-                            <staffDef clef.shape="F" clef.line="4" key.sig="2f" n="2" lines="5" />
+                            <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5">
+                                <keySig sig="2f" />
+                            </staffDef>
+                            <staffDef clef.shape="F" clef.line="4" n="2" lines="5">
+                                <keySig sig="2f" type="supplied" />
+                            </staffDef>
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="1">
+                        <measure n="37">
                             <staff n="1">
                                 <layer n="1">
+                                    <supplied resp="#rettinghaus">
+                                        <space dur="4" />
+                                        <space dur="8" />
+                                    </supplied>
                                     <beam>
                                         <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="e" />
@@ -56,6 +64,10 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
+                                    <supplied resp="#rettinghaus">
+                                        <note dur="4" oct="3" pname="d" />
+                                        <rest dur="8" />
+                                    </supplied>
                                     <note dur="8" oct="4" pname="d" />
                                     <beam>
                                         <note dur="8" oct="4" pname="d" />
@@ -65,8 +77,28 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.5">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4.5">
+                                <fb>
+                                    <f>5♭</f>
+                                </fb>
+                            </harm>
                         </measure>
-                        <measure n="2">
+                        <measure n="38">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -103,21 +135,55 @@
                                 </layer>
                             </staff>
                             <staff n="2">
-                                <layer xml:id="ex-1280" n="1">
+                                <layer n="1">
                                     <clef shape="C" line="4" />
-                                    <note dur="4" oct="4" pname="e" />
+                                    <note dur="4" oct="4" pname="e">
+                                        <accid accid="f" />
+                                    </note>
                                     <rest dur="8" />
-                                    <note dur="8" oct="4" pname="e" />
+                                    <note dur="8" oct="4" pname="e" accid.ges="f" />
                                     <beam>
-                                        <note dur="8" oct="4" pname="e" accid="n" />
+                                        <note dur="8" oct="4" pname="e">
+                                            <accid accid="n" />
+                                        </note>
                                         <note dur="8" oct="4" pname="e" />
                                         <note dur="8" oct="4" pname="e" />
                                         <note dur="8" oct="4" pname="e" />
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>9</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="1.5">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.5">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4.5">
+                                <fb>
+                                    <f>5♭</f>
+                                </fb>
+                            </harm>
                         </measure>
-                        <measure n="3">
+                        <measure n="39">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -157,15 +223,52 @@
                                     <rest dur="8" />
                                     <note dur="8" oct="4" pname="f" />
                                     <beam>
-                                        <note dur="8" oct="4" pname="f" accid="s" />
-                                        <note dur="8" oct="4" pname="f" />
-                                        <note dur="8" oct="4" pname="f" />
-                                        <note dur="8" oct="4" pname="f" />
+                                        <note dur="8" oct="4" pname="f">
+                                            <accid accid="s" />
+                                        </note>
+                                        <note dur="8" oct="4" pname="f" accid.ges="s" />
+                                        <note dur="8" oct="4" pname="f" accid.ges="s" />
+                                        <note dur="8" oct="4" pname="f" accid.ges="s" />
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>9</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="1.5">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2.5">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.5">
+                                <fb>
+                                    <f>♮7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                                <fb>
+                                    <f>6♭</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4.5">
+                                <fb>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
-                        <measure n="4" right="invis" metcon="false">
+                        <measure n="40" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -194,6 +297,16 @@
                                     <custos oct="4" pname="c" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>9</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="1.5">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
                         </measure>
                     </section>
                 </score>

--- a/data/9/music-example1.mei
+++ b/data/9/music-example1.mei
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title></title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -19,102 +18,101 @@
                 <edition>First draft, <date>2019</date></edition>
             </editionStmt>
             <pubStmt>
-                <unpub/>
+                <unpub />
             </pubStmt>
         </fileDesc>
     </meiHead>
-
     <music>
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
+                    <scoreDef mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5"/>
-                            <staffDef clef.shape="F" clef.line="4" key.sig="2f" n="2" lines="5"/>
+                            <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5" />
+                            <staffDef clef.shape="F" clef.line="4" key.sig="2f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <measure n="1">
                             <staff n="1">
                                 <layer n="1">
-                                  <beam>
-                                      <note dur="16" oct="5" pname="f"/>
-                                      <note dur="16" oct="5" pname="e"/>
-                                  </beam>
-                                  <beam>
-                                      <note dur="16" oct="5" pname="d"/>
-                                      <note dur="16" oct="5" pname="f"/>
-                                      <note dur="16" oct="5" pname="c"/>
-                                      <note dur="16" oct="5" pname="f"/>
-                                  </beam>
-                                  <beam>
-                                      <note dur="16" oct="4" pname="b"/>
-                                      <note dur="16" oct="5" pname="f"/>
-                                      <note dur="16" oct="4" pname="a" accid="f"/>
-                                      <note dur="16" oct="5" pname="f"/>
-                                  </beam>
-                              </layer>
+                                    <beam>
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="5" pname="e" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="5" pname="d" />
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="f" />
+                                    </beam>
+                                    <beam>
+                                        <note dur="16" oct="4" pname="b" />
+                                        <note dur="16" oct="5" pname="f" />
+                                        <note dur="16" oct="4" pname="a" accid="f" />
+                                        <note dur="16" oct="5" pname="f" />
+                                    </beam>
+                                </layer>
                             </staff>
                             <staff n="2">
-                              <layer n="1">
-                                <note dur="8" oct="4" pname="d"/>
-                                <beam>
-                                  <note dur="8" oct="4" pname="d"/>
-                                  <note dur="8" oct="4" pname="d"/>
-                                  <note dur="8" oct="4" pname="d"/>
-                                  <note dur="8" oct="4" pname="d"/>
-                                </beam>
-                              </layer>
+                                <layer n="1">
+                                    <note dur="8" oct="4" pname="d" />
+                                    <beam>
+                                        <note dur="8" oct="4" pname="d" />
+                                        <note dur="8" oct="4" pname="d" />
+                                        <note dur="8" oct="4" pname="d" />
+                                        <note dur="8" oct="4" pname="d" />
+                                    </beam>
+                                </layer>
                             </staff>
                         </measure>
                         <measure n="2">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="g"/>
-                                        <note dur="16" oct="5" pname="f"/>
+                                        <note dur="16" oct="4" pname="g" />
+                                        <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="5" pname="d" />
                                     </beam>
                                     <beam>
                                         <note dur="8" oct="5" pname="e">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="g"/>
-                                        <note dur="16" oct="5" pname="f"/>
+                                        <note dur="16" oct="5" pname="g" />
+                                        <note dur="16" oct="5" pname="f" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="5" pname="e">
-                                            <accid accid="n"/>
+                                            <accid accid="n" />
                                         </note>
-                                        <note dur="16" oct="5" pname="g"/>
-                                        <note dur="16" oct="5" pname="d"/>
-                                        <note dur="16" oct="5" pname="g"/>
+                                        <note dur="16" oct="5" pname="g" />
+                                        <note dur="16" oct="5" pname="d" />
+                                        <note dur="16" oct="5" pname="g" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="5" pname="c"/>
-                                        <note dur="16" oct="5" pname="g"/>
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="4" pname="b">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="g"/>
+                                        <note dur="16" oct="5" pname="g" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer xml:id="ex-1280" n="1">
-                                    <clef shape="C" line="4"/>
-                                    <note dur="4" oct="4" pname="e"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="4" pname="e"/>
+                                    <clef shape="C" line="4" />
+                                    <note dur="4" oct="4" pname="e" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="4" pname="e" />
                                     <beam>
-                                        <note dur="8" oct="4" pname="e" accid="n"/>
-                                        <note dur="8" oct="4" pname="e"/>
-                                        <note dur="8" oct="4" pname="e"/>
-                                        <note dur="8" oct="4" pname="e"/>
+                                        <note dur="8" oct="4" pname="e" accid="n" />
+                                        <note dur="8" oct="4" pname="e" />
+                                        <note dur="8" oct="4" pname="e" />
+                                        <note dur="8" oct="4" pname="e" />
                                     </beam>
                                 </layer>
                             </staff>
@@ -123,75 +121,77 @@
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="a"/>
-                                        <note dur="16" oct="5" pname="g"/>
-                                        <note dur="16" oct="5" pname="f"/>
+                                        <note dur="16" oct="4" pname="a" />
+                                        <note dur="16" oct="5" pname="g" />
+                                        <note dur="16" oct="5" pname="f" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid accid="n"/>
+                                            <accid accid="n" />
                                         </note>
                                     </beam>
                                     <beam>
-                                        <note dur="8" oct="5" pname="f"/>
-                                        <note dur="16" oct="5" pname="a"/>
-                                        <note dur="16" oct="5" pname="g"/>
+                                        <note dur="8" oct="5" pname="f" />
+                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="g" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="5" pname="f">
-                                            <accid accid="s"/>
+                                            <accid accid="s" />
                                         </note>
-                                        <note dur="16" oct="5" pname="a"/>
+                                        <note dur="16" oct="5" pname="a" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid accid="n"/>
+                                            <accid accid="n" />
                                         </note>
-                                        <note dur="16" oct="5" pname="a"/>
+                                        <note dur="16" oct="5" pname="a" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="5" pname="d"/>
-                                        <note dur="16" oct="5" pname="a"/>
-                                        <note dur="16" oct="5" pname="c"/>
-                                        <note dur="16" oct="5" pname="a"/>
+                                        <note dur="16" oct="5" pname="d" />
+                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="a" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note dur="4" oct="4" pname="f"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="4" pname="f"/>
+                                    <note dur="4" oct="4" pname="f" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="4" pname="f" />
                                     <beam>
-                                        <note dur="8" oct="4" pname="f" accid="s"/>
-                                        <note dur="8" oct="4" pname="f"/>
-                                        <note dur="8" oct="4" pname="f"/>
-                                        <note dur="8" oct="4" pname="f"/>
+                                        <note dur="8" oct="4" pname="f" accid="s" />
+                                        <note dur="8" oct="4" pname="f" />
+                                        <note dur="8" oct="4" pname="f" />
+                                        <note dur="8" oct="4" pname="f" />
                                     </beam>
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="4">
+                        <measure n="4" right="invis" metcon="false">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
                                         <note dur="16" oct="4" pname="b">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="a"/>
-                                        <note dur="16" oct="5" pname="g"/>
+                                        <note dur="16" oct="5" pname="a" />
+                                        <note dur="16" oct="5" pname="g" />
                                         <note dur="16" oct="5" pname="f">
-                                            <accid xml:id="ex-1344" accid="s"/>
+                                            <accid accid="s" />
                                         </note>
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="5" pname="g"/>
-                                        <note dur="16" oct="5" pname="d"/>
-                                        <note dur="16" oct="5" pname="c"/>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="5" pname="g" />
+                                        <note dur="16" oct="5" pname="d" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="5" pname="d" />
                                     </beam>
+                                    <custos oct="4" pname="e" />
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note dur="4" dots="1" oct="4" pname="g"/>
-                                    <note dur="8" oct="3" pname="b"/>
+                                    <note dur="4" dots="1" oct="4" pname="g" />
+                                    <note dur="8" oct="3" pname="b" />
+                                    <custos oct="4" pname="c" />
                                 </layer>
                             </staff>
                         </measure>

--- a/data/9/music-example2.mei
+++ b/data/9/music-example2.mei
@@ -36,10 +36,9 @@
                         </staffGrp>
                     </scoreDef>
                     <section>
-                        <measure n="1">
+                        <measure metcon="false">
                             <staff n="1">
                                 <layer n="1">
-                                    <space dur="2" />
                                     <beam>
                                         <note dur="16" oct="5" pname="e" />
                                         <note dur="16" oct="5" pname="c" />
@@ -56,14 +55,12 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <space dots="1" dur="4" />
-                                    <space dur="8" />
                                     <note dots="1" dur="4" oct="4" pname="c" />
                                     <note dur="8" oct="4" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="2">
+                        <measure n="42">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -115,7 +112,7 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="3">
+                        <measure n="43">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
@@ -163,7 +160,7 @@
                                 </layer>
                             </staff>
                         </measure>
-                        <measure n="4">
+                        <measure n="44">
                             <staff n="1">
                                 <layer n="1">
                                     <beam>

--- a/data/9/music-example2.mei
+++ b/data/9/music-example2.mei
@@ -129,6 +129,7 @@
                                         </note>
                                         <note dur="16" oct="5" pname="d" />
                                     </beam>
+                                    <sb />
                                     <beam>
                                         <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="a">
@@ -154,6 +155,7 @@
                                     <note dur="4" oct="3" pname="e" />
                                     <rest dur="8" />
                                     <note dur="8" oct="3" pname="e" />
+                                    <sb />
                                     <note dur="4" oct="3" pname="a" accid="f" />
                                     <rest dur="8" />
                                     <note dur="8" oct="3" pname="a" />

--- a/data/9/music-example2.mei
+++ b/data/9/music-example2.mei
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
-                <title>
-                </title>
+                <title></title>
                 <composer>
                     <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
                 </composer>
@@ -16,10 +15,13 @@
                 </respStmt>
             </titleStmt>
             <editionStmt>
-                <edition>First draft, <date>2019</date></edition>
+                <edition>
+                    First draft,
+                    <date>2019</date>
+                </edition>
             </editionStmt>
             <pubStmt>
-                <unpub/>
+                <unpub />
             </pubStmt>
         </fileDesc>
     </meiHead>
@@ -27,37 +29,37 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
+                    <scoreDef mnum.visible="false">
                         <staffGrp>
-                            <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5"/>
-                            <staffDef clef.shape="F" clef.line="4" key.sig="2f" n="2" lines="5"/>
+                            <staffDef clef.shape="C" clef.line="1" key.sig="2f" n="1" lines="5" />
+                            <staffDef clef.shape="F" clef.line="4" key.sig="2f" n="2" lines="5" />
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <measure n="1">
                             <staff n="1">
                                 <layer n="1">
-                                    <space dur="2"/>
+                                    <space dur="2" />
                                     <beam>
-                                        <note dur="16" oct="5" pname="e"/>
-                                        <note dur="16" oct="5" pname="c"/>
-                                        <note dur="16" oct="4" pname="b"/>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="5" pname="e" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="4" pname="b" />
+                                        <note dur="16" oct="5" pname="c" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="a" accid="f"/>
-                                        <note dur="16" oct="5" pname="e"/>
-                                        <note dur="16" oct="4" pname="g"/>
-                                        <note dur="16" oct="5" pname="e"/>
+                                        <note dur="16" oct="4" pname="a" accid="f" />
+                                        <note dur="16" oct="5" pname="e" />
+                                        <note dur="16" oct="4" pname="g" />
+                                        <note dur="16" oct="5" pname="e" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <space dots="1" dur="4"/>
-                                    <space dur="8"/>
-                                    <note dots="1" dur="4" oct="4" pname="c"/>
-                                    <note dur="8" oct="4" pname="c"/>
+                                    <space dots="1" dur="4" />
+                                    <space dur="8" />
+                                    <note dots="1" dur="4" oct="4" pname="c" />
+                                    <note dur="8" oct="4" pname="c" />
                                 </layer>
                             </staff>
                         </measure>
@@ -65,51 +67,51 @@
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="a" accid="f"/>
+                                        <note dur="16" oct="4" pname="a" accid="f" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid  accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="4" pname="g"/>
+                                        <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid  accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="a"/>
+                                        <note dur="16" oct="4" pname="a" />
                                         <note dur="16" oct="5" pname="e">
-                                            <accid  accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="5" pname="c" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="4" pname="b">
-                                            <accid  accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
                                         <note dur="16" oct="4" pname="a">
-                                            <accid  accid="f"/>
+                                            <accid accid="f" />
                                         </note>
                                         <note dur="16" oct="4" pname="b">
-                                            <accid  accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="g"/>
-                                        <note dur="16" oct="5" pname="d"/>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="4" pname="g" />
+                                        <note dur="16" oct="5" pname="d" />
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="5" pname="d" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note dur="4" oct="3" pname="f"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="3" pname="f"/>
-                                    <note dur="4" oct="3" pname="b" accid="f"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="3" pname="b"/>
+                                    <note dur="4" oct="3" pname="f" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="3" pname="f" />
+                                    <note dur="4" oct="3" pname="b" accid="f" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="3" pname="b" />
                                 </layer>
                             </staff>
                         </measure>
@@ -117,47 +119,47 @@
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="g"/>
-                                        <note dur="16" oct="5" pname="d"/>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="4" pname="g" />
+                                        <note dur="16" oct="5" pname="d" />
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="5" pname="d" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="g"/>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="4" pname="g" />
+                                        <note dur="16" oct="5" pname="d" />
                                         <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="d"/>
+                                        <note dur="16" oct="5" pname="d" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="a">
-                                            <accid accid="f"/>
+                                            <accid accid="f" />
                                         </note>
-                                        <note dur="16" oct="4" pname="g"/>
+                                        <note dur="16" oct="4" pname="g" />
                                         <note dur="16" oct="4" pname="a">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="5" pname="c" />
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note dur="4" oct="3" pname="e"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="3" pname="e"/>
-                                    <note dur="4" oct="3" pname="a" accid="f"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="3" pname="a"/>
+                                    <note dur="4" oct="3" pname="e" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="3" pname="e" />
+                                    <note dur="4" oct="3" pname="a" accid="f" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="3" pname="a" />
                                 </layer>
                             </staff>
                         </measure>
@@ -165,47 +167,47 @@
                             <staff n="1">
                                 <layer n="1">
                                     <beam>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="5" pname="c" />
                                         <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="5" pname="c" />
                                     </beam>
                                     <beam>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="5" pname="c"/>
-                                        <note dur="16" oct="4" pname="d"/>
-                                        <note dur="16" oct="5" pname="c"/>
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="4" pname="d" />
+                                        <note dur="16" oct="5" pname="c" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="4" pname="b">
-                                            <accid accid="n"/>
+                                            <accid accid="n" />
                                         </note>
-                                        <note dur="16" oct="4" pname="g"/>
-                                        <note dur="16" oct="4" pname="f"/>
-                                        <note dur="16" oct="4" pname="g"/>
+                                        <note dur="16" oct="4" pname="g" />
+                                        <note dur="16" oct="4" pname="f" />
+                                        <note dur="16" oct="4" pname="g" />
                                     </beam>
                                     <beam>
                                         <note dur="16" oct="4" pname="e">
-                                            <accid accid.ges="f"/>
+                                            <accid accid.ges="f" />
                                         </note>
-                                        <note dur="16" oct="5" pname="c"/>
-                                        <note dur="16" oct="4" pname="d"/>
+                                        <note dur="16" oct="5" pname="c" />
+                                        <note dur="16" oct="4" pname="d" />
                                         <note dur="16" oct="4" pname="b">
-                                            <accid accid="n" func="caution"/>
+                                            <accid accid="n" func="caution" />
                                         </note>
                                     </beam>
                                 </layer>
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note dur="4" oct="3" pname="d"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="3" pname="d"/>
-                                    <note dur="4" oct="3" pname="g"/>
-                                    <rest dur="8"/>
-                                    <note dur="8" oct="3" pname="g"/>
+                                    <note dur="4" oct="3" pname="d" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="3" pname="d" />
+                                    <note dur="4" oct="3" pname="g" />
+                                    <rest dur="8" />
+                                    <note dur="8" oct="3" pname="g" />
                                 </layer>
                             </staff>
                         </measure>

--- a/data/9/music-example2.mei
+++ b/data/9/music-example2.mei
@@ -55,10 +55,31 @@
                             </staff>
                             <staff n="2">
                                 <layer n="1">
-                                    <note dots="1" dur="4" oct="4" pname="c" />
+                                    <note dur="4" oct="4" pname="c" />
+                                    <rest dur="8" />
                                     <note dur="8" oct="4" pname="c" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="1.5">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="2.5">
+                                <fb>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure n="42">
                             <staff n="1">
@@ -111,6 +132,31 @@
                                     <note dur="8" oct="3" pname="b" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.5">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4.5">
+                                <fb>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure n="43">
                             <staff n="1">
@@ -161,6 +207,31 @@
                                     <note dur="8" oct="3" pname="a" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.5">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4.5">
+                                <fb>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure n="44">
                             <staff n="1">
@@ -209,6 +280,31 @@
                                     <note dur="8" oct="3" pname="g" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="2" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3">
+                                <fb>
+                                    <f>8</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="3.5">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="2" tstamp="4.5">
+                                <fb>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                     </section>
                 </score>

--- a/data/9/score.mei
+++ b/data/9/score.mei
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="4.0.0">
   <meiHead>
     <fileDesc>

--- a/data/9/score.mei
+++ b/data/9/score.mei
@@ -144,7 +144,7 @@
               </staffGrp>
             </scoreDef>
             <section xml:id="m-34">
-              <measure xml:id="m-35" metcon="false" n="1">
+              <measure xml:id="m-35" metcon="false">
                 <staff xml:id="m-37" n="1">
                   <layer xml:id="m-38" n="1">
                     <mSpace/>
@@ -164,7 +164,7 @@
                 </staff>
                 <tempo place="above" startid="#m-42">Allegro.</tempo>
               </measure>
-              <measure xml:id="m-50" label="1" n="2">
+              <measure xml:id="m-50" label="1" n="1">
                 <staff xml:id="m-51" n="1">
                   <layer xml:id="m-52" n="1">
                     <mSpace/>
@@ -229,7 +229,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-81" n="3">
+              <measure xml:id="m-81" n="2">
                 <staff xml:id="m-82" n="1">
                   <layer xml:id="m-83" n="1">
                     <mSpace/>
@@ -292,7 +292,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-111" n="4">
+              <measure xml:id="m-111" n="3">
                 <staff xml:id="m-113" n="1">
                   <layer xml:id="m-114" n="1">
                     <mSpace/>
@@ -344,7 +344,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-141" n="5">
+              <measure xml:id="m-141" n="4">
                 <staff xml:id="m-142" n="1">
                   <layer xml:id="m-143" n="1">
                     <mSpace/>
@@ -412,7 +412,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-178" n="6">
+              <measure xml:id="m-178" n="5">
                 <staff xml:id="m-180" n="1">
                   <layer xml:id="m-181" n="1">
                     <mSpace/>
@@ -467,7 +467,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-210" n="7">
+              <measure xml:id="m-210" n="6">
                 <staff xml:id="m-211" n="1">
                   <layer xml:id="m-212" n="1">
                     <mSpace/>
@@ -533,7 +533,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-243" n="8">
+              <measure xml:id="m-243" n="7">
                 <staff xml:id="m-244" n="1">
                   <layer xml:id="m-245" n="1">
                     <space xml:id="m-246" dur="2"/>
@@ -587,7 +587,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-270" n="9">
+              <measure xml:id="m-270" n="8">
                 <staff xml:id="m-272" n="1">
                   <layer xml:id="m-273" n="1">
                     <beam xml:id="m-275">
@@ -650,7 +650,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-308" n="10">
+              <measure xml:id="m-308" n="9">
                 <staff xml:id="m-309" n="1">
                   <layer xml:id="m-310" n="1">
                     <beam xml:id="m-313">
@@ -699,7 +699,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-335" n="11">
+              <measure xml:id="m-335" n="10">
                 <staff xml:id="m-336" n="1"/>
                 <staff xml:id="m-337" n="2" facs="#facsZone-m-337">
                   <layer xml:id="m-338" n="1">
@@ -758,7 +758,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-368" n="12">
+              <measure xml:id="m-368" n="11">
                 <staff xml:id="m-370" n="1"/>
                 <staff xml:id="m-371" n="2" facs="#facsZone-m-371">
                   <layer xml:id="m-372" n="1">
@@ -828,7 +828,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-402" n="13">
+              <measure xml:id="m-402" n="12">
                 <staff xml:id="m-403" n="1"/>
                 <staff xml:id="m-404" n="2" facs="#facsZone-m-404">
                   <layer xml:id="m-405" n="1">
@@ -883,7 +883,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-436" n="14">
+              <measure xml:id="m-436" n="13">
                 <staff xml:id="m-437" n="1">
                   <layer xml:id="m-438" n="1">
                     <beam xml:id="m-440">
@@ -948,7 +948,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-473" n="15">
+              <measure xml:id="m-473" n="14">
                 <staff xml:id="m-475" n="1">
                   <layer xml:id="m-476" n="1">
                     <beam xml:id="m-479">
@@ -1022,7 +1022,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-516" n="16">
+              <measure xml:id="m-516" n="15">
                 <staff xml:id="m-517" n="1">
                   <layer xml:id="m-518" n="1">
                     <note xml:id="m-519" dur="4" oct="5" pname="d"/>
@@ -1079,7 +1079,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-543" n="17">
+              <measure xml:id="m-543" n="16">
                 <staff xml:id="m-544" n="1"/>
                 <staff xml:id="m-545" n="2" facs="#facsZone-m-545">
                   <layer xml:id="m-546" n="1">
@@ -1144,7 +1144,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-573" n="18">
+              <measure xml:id="m-573" n="17">
                 <staff xml:id="m-576" n="1"/>
                 <staff xml:id="m-577" n="2" facs="#facsZone-m-577">
                   <layer xml:id="m-578" n="1">
@@ -1200,7 +1200,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-609" n="19">
+              <measure xml:id="m-609" n="18">
                 <staff xml:id="m-610" n="1"/>
                 <staff xml:id="m-611" n="2" facs="#facsZone-m-611">
                   <layer xml:id="m-612" n="1">
@@ -1256,7 +1256,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-640" n="20">
+              <measure xml:id="m-640" n="19">
                 <staff xml:id="m-641" n="1"/>
                 <staff xml:id="m-642" n="2" facs="#facsZone-m-642">
                   <layer xml:id="m-643" n="1">
@@ -1306,7 +1306,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-668" n="21">
+              <measure xml:id="m-668" n="20">
                 <staff xml:id="m-670" n="1">
                   <layer xml:id="m-671" n="1">
                     <rest xml:id="m-672" dur="2"/>
@@ -1358,7 +1358,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-701" n="22">
+              <measure xml:id="m-701" n="21">
                 <staff xml:id="m-702" n="1">
                   <layer xml:id="m-703" n="1">
                     <beam xml:id="m-706">
@@ -1424,7 +1424,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-742" n="23">
+              <measure xml:id="m-742" n="22">
                 <staff xml:id="m-743" n="1">
                   <layer xml:id="m-744" n="1">
                     <beam xml:id="m-746">
@@ -1499,7 +1499,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-781" n="24">
+              <measure xml:id="m-781" n="23">
                 <staff xml:id="m-783" n="1">
                   <layer xml:id="m-784" n="1">
                     <note xml:id="m-785" dur="4" oct="5" pname="d"/>
@@ -1539,7 +1539,7 @@
                   </layer>
                 </staff>
               </measure>
-              <measure xml:id="m-809" n="25">
+              <measure xml:id="m-809" n="24">
                 <staff xml:id="m-810" n="1">
                   <layer xml:id="m-811" n="1">
                     <space xml:id="m-812" dur="4"/>
@@ -1590,7 +1590,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-836" n="26">
+              <measure xml:id="m-836" n="25">
                 <staff xml:id="m-837" n="1">
                   <layer xml:id="m-838" n="1">
                     <beam xml:id="m-841">
@@ -1660,7 +1660,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-876" n="27">
+              <measure xml:id="m-876" n="26">
                 <staff xml:id="m-878" n="1">
                   <layer xml:id="m-879" n="1">
                     <note xml:id="m-880" dur="4" oct="5" pname="d"/>
@@ -1703,7 +1703,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-899" n="28">
+              <measure xml:id="m-899" n="27">
                 <staff xml:id="m-900" n="1"/>
                 <staff xml:id="m-901" n="2" facs="#facsZone-m-901 #facsZone-m-901-2 #facsZone-m-901-2">
                   <layer xml:id="m-902" n="1">
@@ -1760,7 +1760,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-928" n="29">
+              <measure xml:id="m-928" n="28">
                 <staff xml:id="m-929" n="1"/>
                 <staff xml:id="m-930" n="2" facs="#facsZone-m-930 #facsZone-m-930-2">
                   <layer xml:id="m-931" n="1">
@@ -1821,7 +1821,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-956" n="30">
+              <measure xml:id="m-956" n="29">
                 <staff xml:id="m-958" n="1"/>
                 <staff xml:id="m-959" n="2" facs="#facsZone-m-959">
                   <layer xml:id="m-960" n="1">
@@ -1878,7 +1878,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-986" n="31">
+              <measure xml:id="m-986" n="30">
                 <staff xml:id="m-987" n="1"/>
                 <staff xml:id="m-988" n="2" facs="#facsZone-m-988">
                   <layer xml:id="m-989" n="1">
@@ -1939,7 +1939,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1014" n="32">
+              <measure xml:id="m-1014" n="31">
                 <staff xml:id="m-1016" n="1"/>
                 <staff xml:id="m-1017" n="2" facs="#facsZone-m-1017">
                   <layer xml:id="m-1018" n="1">
@@ -2000,7 +2000,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1044" n="33">
+              <measure xml:id="m-1044" n="32">
                 <staff xml:id="m-1045" n="1">
                   <layer xml:id="m-1046" n="1">
                     <rest xml:id="m-1047" dur="8"/>
@@ -2095,7 +2095,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1098" n="34">
+              <measure xml:id="m-1098" n="33">
                 <staff xml:id="m-1099" n="1">
                   <layer xml:id="m-1100" n="1">
                     <note xml:id="m-1101" dur="4" oct="5" pname="c"/>
@@ -2162,7 +2162,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1130" n="35">
+              <measure xml:id="m-1130" n="34">
                 <staff xml:id="m-1132" n="1">
                   <layer xml:id="m-1133" n="1">
                     <note xml:id="m-1134" dur="4" oct="4" pname="a"/>
@@ -2208,7 +2208,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1157" n="36">
+              <measure xml:id="m-1157" n="35">
                 <staff xml:id="m-1158" n="1">
                   <layer xml:id="m-1159" n="1">
                     <mSpace/>
@@ -2263,7 +2263,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1187" n="37">
+              <measure xml:id="m-1187" n="36">
                 <staff xml:id="m-1188" n="1">
                   <layer xml:id="m-1189" n="1">
                     <mSpace/>
@@ -2323,7 +2323,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1220" n="38">
+              <measure xml:id="m-1220" n="37">
                 <staff xml:id="m-1223" n="1">
                   <layer xml:id="m-1224" n="1">
                     <space xml:id="m-1225" dur="4"/>
@@ -2397,7 +2397,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1253" n="39">
+              <measure xml:id="m-1253" n="38">
                 <staff xml:id="m-1254" n="1">
                   <layer xml:id="m-1255" n="1">
                     <beam xml:id="m-1257">
@@ -2475,7 +2475,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1295" n="40">
+              <measure xml:id="m-1295" n="39">
                 <staff xml:id="m-1296" n="1">
                   <layer xml:id="m-1297" n="1">
                     <beam xml:id="m-1299">
@@ -2562,7 +2562,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1334" n="41">
+              <measure xml:id="m-1334" n="40">
                 <staff xml:id="m-1336" n="1">
                   <layer xml:id="m-1337" n="1">
                     <beam xml:id="m-1340">
@@ -2633,7 +2633,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1372" n="42">
+              <measure xml:id="m-1372" n="41">
                 <staff xml:id="m-1373" n="1">
                   <layer xml:id="m-1374" n="1">
                     <beam xml:id="m-1376">
@@ -2704,7 +2704,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1412" n="43">
+              <measure xml:id="m-1412" n="42">
                 <staff xml:id="m-1413" n="1">
                   <layer xml:id="m-1414" n="1">
                     <beam xml:id="m-1416">
@@ -2781,7 +2781,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1451" n="44">
+              <measure xml:id="m-1451" n="43">
                 <staff xml:id="m-1453" n="1">
                   <layer xml:id="m-1454" n="1">
                     <beam xml:id="m-1456">
@@ -2850,7 +2850,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1487" n="45">
+              <measure xml:id="m-1487" n="44">
                 <staff xml:id="m-1488" n="1">
                   <layer xml:id="m-1489" n="1">
                     <space xml:id="m-1490" dur="2"/>
@@ -2912,7 +2912,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1516" n="46">
+              <measure xml:id="m-1516" n="45">
                 <staff xml:id="m-1517" n="1">
                   <layer xml:id="m-1518" n="1">
                     <beam xml:id="m-1520">
@@ -3012,7 +3012,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1574" n="47">
+              <measure xml:id="m-1574" n="46">
                 <staff xml:id="m-1576" n="1">
                   <layer xml:id="m-1577" n="1">
                     <beam xml:id="m-1580">
@@ -3113,7 +3113,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1636" n="48">
+              <measure xml:id="m-1636" n="47">
                 <staff xml:id="m-1637" n="1">
                   <layer xml:id="m-1638" n="1">
                     <mSpace/>
@@ -3168,7 +3168,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1668" n="49">
+              <measure xml:id="m-1668" n="48">
                 <staff xml:id="m-1670" n="1">
                   <layer xml:id="m-1671" n="1">
                     <beam xml:id="m-1673">
@@ -3225,7 +3225,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1706" n="50">
+              <measure xml:id="m-1706" n="49">
                 <staff xml:id="m-1707" n="1">
                   <layer xml:id="m-1708" n="1">
                     <beam xml:id="m-1710">
@@ -3298,7 +3298,7 @@
                   </fb>
                 </harm>
               </measure>
-              <measure xml:id="m-1748" n="51" right="end">
+              <measure xml:id="m-1748" n="50" right="end" metcon="false">
                 <staff xml:id="m-1749" n="1">
                   <layer xml:id="m-1750" n="1">
                     <note xml:id="m-1751" dur="4" oct="4" pname="b">
@@ -3319,21 +3319,21 @@
                       <note xml:id="m-1760" dur="8" oct="3" pname="g"/>
                       <note xml:id="m-1762" dur="8" oct="2" pname="g"/>
                     </beam>
-                    <note xml:id="m-1763" dur="2" oct="3" pname="c"/>
+                    <note xml:id="m-1763" dur="4" oct="3" pname="c"/>
                   </layer>
                 </staff>
-                <harm place="above" staff="2" startid="m-1755">
+                <harm place="above" staff="2" tstamp="1">
                   <fb>
                     <f>♮</f>
                   </fb>
                 </harm>
-                <harm place="above" staff="2" startid="m-1760">
+                <harm place="above" staff="2" tstamp="2">
                   <fb>
                     <f>6</f>
                     <f>4</f>
                   </fb>
                 </harm>
-                <harm place="above" staff="2" startid="m-1762">
+                <harm place="above" staff="2" tstamp="2.5">
                   <fb>
                     <f>♮</f>
                   </fb>


### PR DESCRIPTION
This PR fixes *Probstück 9* as there were all references off by one number. The missing figured bass in the examples are added. 
Also it brings many fixes and improvements to the examples to *Probstück 11*.
