### PR TITLE
improve ps 24

### DIFF
--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1343,13 +1343,13 @@
                                 </fb>
                             </harm>
                             <choice>
-                              <corr>
-                                  <harm place="above" staff="1" tstamp="4">
-                                      <fb>
-                                          <f>6</f>
-                                      </fb>
-                                  </harm>
-                              </corr>
+                                <corr resp="#rettinghaus">
+                                    <harm place="above" staff="1" tstamp="4">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </corr>
                                 <sic>
                                     <harm place="above" staff="1" tstamp="3.75">
                                         <fb>
@@ -1494,11 +1494,22 @@
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2.75">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
+                            <choice>
+                                <corr resp="#rettinghaus">
+                                    <harm place="above" staff="1" tstamp="2">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </corr>
+                                <sic>
+                                    <harm place="above" staff="1" tstamp="2.75">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </sic>
+                            </choice>
                             <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
@@ -66,7 +66,7 @@
                 <score>
                     <scoreDef key.pname="d" key.accid="f" key.mode="major">
                         <staffGrp>
-                            <staffDef n='1' lines='5' clef.shape="F" clef.line="4">
+                            <staffDef n="1" lines="5" clef.shape="F" clef.line="4">
                                 <keySig mode="major" sig="4f" />
                                 <meterSig count="4" unit="4" sym="common" />
                             </staffDef>
@@ -102,26 +102,25 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
-                                <fb>
-                                </fb>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb></fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -156,22 +155,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -206,12 +205,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -248,12 +247,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -270,23 +269,23 @@
                                     <note xml:id="note-0000000397966656" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                     <f>5</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                     <f>5</f>
@@ -314,12 +313,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -346,42 +345,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -408,22 +407,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
@@ -446,22 +445,22 @@
                                     <rest xml:id="rest-0000001100153303" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -493,32 +492,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>♭</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>♭</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
@@ -539,12 +538,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -574,12 +573,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -612,22 +611,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -660,12 +659,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -698,12 +697,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -730,12 +729,12 @@
                                     <note xml:id="note-0000001194843831" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -753,13 +752,13 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                     <f>5</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                     <f>5</f>
@@ -787,32 +786,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
@@ -839,42 +838,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
@@ -904,32 +903,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -944,24 +943,24 @@
                                     <rest xml:id="rest-0000001740142267" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                     <f>4</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>3</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                     <f>4</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>3</f>
                                 </fb>
@@ -994,12 +993,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1033,22 +1032,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
@@ -1081,12 +1080,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1119,12 +1118,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1190,23 +1189,23 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6⃥</f>
                                     <f>4</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6⃥</f>
                                     <f>4</f>
@@ -1237,12 +1236,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1271,42 +1270,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
@@ -1333,42 +1332,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1395,42 +1394,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1452,22 +1451,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6⃥</f>
                                 </fb>
@@ -1494,22 +1493,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1527,34 +1526,34 @@
                                     <note xml:id="note-0000001236971930" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                     <f>5</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                     <f>5</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>♮</f>
                                 </fb>
@@ -1577,12 +1576,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1615,22 +1614,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1653,14 +1652,14 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                     <f>4</f>
                                     <f>2</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                     <f>4</f>
@@ -1695,32 +1694,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3.75">
+                            <harm place="above" staff="1" tstamp="3.75">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3.75">
+                            <harm place="above" staff="1" tstamp="3.75">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1784,12 +1783,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1818,22 +1817,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -1871,32 +1870,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2.75">
+                            <harm place="above" staff="1" tstamp="2.75">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2.75">
+                            <harm place="above" staff="1" tstamp="2.75">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
@@ -1914,9 +1913,8 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
-                                <fb>
-                                </fb>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb></fb>
                             </harm>
                         </measure>
                         <measure xml:id="measure-0000001968799557" n="44">
@@ -1940,32 +1938,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
@@ -1993,42 +1991,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
@@ -2059,42 +2057,42 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="3">
+                            <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>7</f>
                                 </fb>
@@ -2121,22 +2119,22 @@
                                     <clef xml:id="clef-0000000352065921" shape="F" line="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -2168,12 +2166,12 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -2204,22 +2202,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="4">
+                            <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
                                 </fb>
@@ -2234,24 +2232,24 @@
                                     <rest xml:id="rest-0000001944516741" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                     <f>4</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>3</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="1">
+                            <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
                                     <f>4</f>
                                 </fb>
                             </harm>
-                            <harm place='above' staff="1" tstamp="2">
+                            <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>3</f>
                                 </fb>
@@ -2265,7 +2263,7 @@
                     <section>
                         <scoreDef key.pname="c" key.accid="s" key.mode="major">
                             <staffGrp>
-                                <staffDef n='1' lines='5' clef.shape="F" clef.line="4">
+                                <staffDef n="1" lines="5" clef.shape="F" clef.line="4">
                                     <keySig mode="major" sig="7s" />
                                     <meterSig count="4" unit="4" sym="common" />
                                 </staffDef>
@@ -3450,8 +3448,8 @@
                                 </staff>
                             </measure>
                         </section>
-                    </score>
-                </mdiv>
-            </body>
-        </music>
-    </mei>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -4,7 +4,7 @@
   <meiHead>
     <fileDesc>
       <titleStmt>
-        <title>Der Ober-Classe Vier und zwantzigstes und letztes Prob-Stück.</title>
+        <title>Der Ober-Classe vierundzwantzigstes und letztes Prob-Stück.</title>
         <composer>
           <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
         </composer>
@@ -103,22 +103,17 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001408034959" n="2">
@@ -152,19 +147,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002035340213" n="3">
@@ -198,11 +189,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000898324425" n="4">
@@ -238,11 +227,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000102124254" n="5">
@@ -258,23 +245,17 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                                 <f>5</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                                 <f>5</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002102707351" n="6">
@@ -300,11 +281,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000891114586" n="7">
@@ -330,35 +309,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001738618248" n="8">
@@ -384,19 +355,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000162621610" n="9">
@@ -418,19 +385,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000814073511" n="10">
@@ -461,27 +424,21 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>♭</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>♭</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001710838335" n="11">
@@ -501,11 +458,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002006122533" n="12">
@@ -534,11 +489,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000539415091" n="13">
@@ -570,19 +523,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001263701703" n="14">
@@ -614,11 +563,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000355189963" n="15">
@@ -650,11 +597,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001858057008" n="16">
@@ -680,11 +625,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000142862741" n="17">
@@ -701,15 +644,11 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                                 <f>5</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                                 <f>5</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000198373802" n="18">
@@ -735,27 +674,21 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001832926414" n="19">
@@ -781,35 +714,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002043015754" n="20">
@@ -838,27 +763,21 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001406646077" right="rptend" n="21">
@@ -872,23 +791,17 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                                 <f>4</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                                 <f>4</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000597261657" left="rptstart" n="22">
@@ -920,11 +833,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001265165097" n="23">
@@ -957,19 +868,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001132427062" n="24">
@@ -1001,11 +908,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002003382240" n="25">
@@ -1037,11 +942,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000585450956" n="26">
@@ -1106,23 +1009,17 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
-
                                 <f>4</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
-
                                 <f>4</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000435002289" n="28">
@@ -1151,11 +1048,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000199158692" n="29">
@@ -1183,35 +1078,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001295016694" n="30">
@@ -1237,35 +1124,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000875647534" n="31">
@@ -1291,35 +1170,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001573203733" n="32">
@@ -1340,19 +1211,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000744730060" n="33">
@@ -1378,19 +1245,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001121800967" n="34">
@@ -1407,31 +1270,23 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                                 <f>5</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                                 <f>5</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001066470152" n="35">
@@ -1453,11 +1308,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000493740974" n="36">
@@ -1489,19 +1342,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000950606191" n="37">
@@ -1523,19 +1372,13 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                                 <f>4</f>
-
                                 <f>2</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                                 <f>4</f>
-
                                 <f>2</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000765924639" n="38">
@@ -1567,27 +1410,21 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3.750000"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3.750000"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000669748467" n="39">
@@ -1650,11 +1487,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000493479060" n="41">
@@ -1682,19 +1517,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000028673485" n="42">
@@ -1731,27 +1562,21 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2.750000"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2.750000"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001397417464" n="43">
@@ -1767,7 +1592,6 @@
                                 </layer>
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001968799557" n="44">
@@ -1793,27 +1617,21 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002107539468" n="45">
@@ -1840,35 +1658,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000001839542913" n="46">
@@ -1898,35 +1708,27 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000601026268" n="47">
@@ -1952,19 +1754,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000000496458078" n="48">
@@ -1995,11 +1793,9 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002102094302" n="49">
@@ -2029,19 +1825,15 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
-
                             </fb></harm>
                         </measure>
                         <measure xml:id="measure-0000002144905428" right="rptend" n="50">
@@ -2055,23 +1847,17 @@
                             </staff>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                                 <f>4</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
-
                                 <f>4</f>
-
                             </fb></harm>
                             <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
-
                             </fb></harm>
                         </measure>
                       </section>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="4.0.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Der Ober-Classe vierundzwantzigstes und letztes Prob-Stück.</title>
-        <composer>
-          <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
-        </composer>
-        <respStmt>
-          <resp>Edited by</resp>
-          <persName role="editor" xml:id="pfeffer">Niels Pfeffer</persName>
-          <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
-        </respStmt>
-      </titleStmt>
-      <pubStmt>
-        <respStmt>
-          <persName role="publisher">Niels Pfeffer</persName>
-        </respStmt>
-        <date>2019</date>
-        <availability>
-          <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
-            <p>Creative Commons Attribution 4.0 International License</p>
-          </useRestrict>
-        </availability>
-      </pubStmt>
-      <sourceDesc>
-        <source n="1" xml:id="firstEdition">
-          <bibl>
-            <identifier type="URI">http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb10527431-0</identifier>
-            <title type="uniform">Exemplarische Organisten-Probe</title>
-            <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
-            <corpName role="publisher">Schiller &amp; Kißner</corpName>
-            <pubPlace>Hamburg</pubPlace>
-            <date>1719</date>
-          </bibl>
-        </source>
-        <source n="2" xml:id="secondEdition">
-          <bibl>
-            <title type="uniform">Grosse General-Baß-Schule</title>
-            <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
-            <corpName role="publisher">Kißner</corpName>
-            <pubPlace>Hamburg</pubPlace>
-            <date>1731</date>
-            <identifier type="URI">http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb10598495-7</identifier>
-          </bibl>
-        </source>
-      </sourceDesc>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application xml:id="sibelius" version="8300">
-          <name type="operating-system">macOS</name>
-        </application>
-        <application version="2.3.0-dev-3df101b">
-          <name>Verovio</name>
-          <p>Transcoded from MusicXML</p>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title>Der Ober-Classe vierundzwantzigstes und letztes Prob-Stück.</title>
+                <composer>
+                    <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
+                </composer>
+                <respStmt>
+                    <resp>Edited by</resp>
+                    <persName role="editor" xml:id="pfeffer">Niels Pfeffer</persName>
+                    <persName role="editor" xml:id="rettinghaus">Klaus Rettinghaus</persName>
+                </respStmt>
+            </titleStmt>
+            <pubStmt>
+                <respStmt>
+                    <persName role="publisher">Niels Pfeffer</persName>
+                </respStmt>
+                <date>2019</date>
+                <availability>
+                    <useRestrict label="licence" auth="https://creativecommons.org/licenses/by/" codedval="4.0">
+                        <p>Creative Commons Attribution 4.0 International License</p>
+                    </useRestrict>
+                </availability>
+            </pubStmt>
+            <sourceDesc>
+                <source n="1" xml:id="firstEdition">
+                    <bibl>
+                        <identifier type="URI">http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb10527431-0</identifier>
+                        <title type="uniform">Exemplarische Organisten-Probe</title>
+                        <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
+                        <corpName role="publisher">Schiller &amp; Kißner</corpName>
+                        <pubPlace>Hamburg</pubPlace>
+                        <date>1719</date>
+                    </bibl>
+                </source>
+                <source n="2" xml:id="secondEdition">
+                    <bibl>
+                        <title type="uniform">Grosse General-Baß-Schule</title>
+                        <persName role="composer" auth.uri="http://d-nb.info/gnd/118578995" auth="GND">Johann Mattheson</persName>
+                        <corpName role="publisher">Kißner</corpName>
+                        <pubPlace>Hamburg</pubPlace>
+                        <date>1731</date>
+                        <identifier type="URI">http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb10598495-7</identifier>
+                    </bibl>
+                </source>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <appInfo>
+                <application xml:id="sibelius" version="8300">
+                    <name type="operating-system">macOS</name>
+                </application>
+                <application version="2.3.0-dev-3df101b">
+                    <name>Verovio</name>
+                    <p>Transcoded from MusicXML</p>
+                </application>
+            </appInfo>
+        </encodingDesc>
+    </meiHead>
+    <music>
         <body>
             <mdiv>
                 <score>
@@ -85,7 +85,7 @@
                                         <note xml:id="note-0000001380106958" dur="16" oct="3" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000280011944" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000001205790150" dur="8" oct="3" pname="g">
                                                 <accid xml:id="accid-0000001001794774" accid="f" accid.ges="f" />
@@ -94,7 +94,7 @@
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000793662346" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000753518098" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001005250124" dur="8" oct="4" pname="d" accid.ges="f" />
@@ -102,20 +102,30 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001408034959" n="2">
                             <staff xml:id="staff-0000000416792484" n="1">
@@ -129,7 +139,7 @@
                                         <note xml:id="note-0000000728341590" dur="16" oct="3" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001068878596" dur="8" oct="3" pname="g">
                                                 <accid xml:id="accid-0000000410164775" accid="f" accid.ges="f" />
                                             </note>
@@ -138,7 +148,7 @@
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000151634065" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000000309819748" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001845351479" dur="8" oct="4" pname="e" accid.ges="f" />
@@ -146,18 +156,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002035340213" n="3">
                             <staff xml:id="staff-0000000379032343" n="1">
@@ -173,14 +191,14 @@
                                         <note xml:id="note-0000001678958301" dur="16" oct="3" pname="g" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001738106491" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000001546567840" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000002055356263" dur="8" oct="4" pname="c" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001791757966" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000259710626" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001931489483" dur="8" oct="4" pname="f" />
@@ -188,15 +206,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000898324425" n="4">
-                            <staff xml:id="staff-0000001923374575" n="1" visible="true">
+                            <staff xml:id="staff-0000001923374575" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000001502607165" dots="1" dur="8" oct="3" pname="g">
@@ -209,14 +231,14 @@
                                         <note xml:id="note-0000000579428252" dur="16" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000192391409" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000001443365037" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001668030848" dur="8" oct="4" pname="d" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000849558763" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001797688346" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000000298641692" dur="8" oct="4" pname="g">
@@ -226,12 +248,16 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000102124254" n="5">
                             <staff xml:id="staff-0000000725181426" n="1">
@@ -244,20 +270,28 @@
                                     <note xml:id="note-0000000397966656" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                                <f>5</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                                <f>5</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002102707351" n="6">
                             <staff xml:id="staff-0000001711936133" n="1">
@@ -272,7 +306,7 @@
                                         <note xml:id="note-0000000206051640" dur="16" oct="4" pname="d" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000741881696" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000000135507982" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000386135334" dur="8" oct="4" pname="c" />
@@ -280,15 +314,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000891114586" n="7">
-                            <staff xml:id="staff-0000001252141370" n="1" visible="true">
+                            <staff xml:id="staff-0000001252141370" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000001267745617" dur="4" oct="3" pname="b" accid.ges="f" />
                                     <beam>
@@ -300,7 +338,7 @@
                                         <note xml:id="note-0000000105451754" dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001840863179" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000413821121" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001436625075" dur="8" oct="4" pname="d" accid.ges="f" />
@@ -308,30 +346,46 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001738618248" n="8">
                             <staff xml:id="staff-0000001861340941" n="1">
@@ -346,7 +400,7 @@
                                         <note xml:id="note-0000000165136544" dur="16" oct="4" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000626269206" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001091484947" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000002039637795" dur="8" oct="4" pname="e" accid.ges="f" />
@@ -354,18 +408,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000162621610" n="9">
                             <staff xml:id="staff-0000000204745892" n="1">
@@ -384,18 +446,26 @@
                                     <rest xml:id="rest-0000001100153303" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000814073511" n="10">
                             <staff xml:id="staff-0000000699080375" n="1">
@@ -409,7 +479,7 @@
                                         <note xml:id="note-0000001527440305" dur="16" oct="3" pname="d" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000865805477" dur="8" oct="3" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000002122219048" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000000048778718" dur="8" oct="3" pname="g">
@@ -423,27 +493,39 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>♭</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>♭</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>♮</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>♭</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>♭</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001710838335" n="11">
-                            <staff xml:id="staff-0000002096950072" n="1" visible="true">
+                            <staff xml:id="staff-0000002096950072" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000001559462941" dur="4" oct="2" pname="b" accid.ges="f" />
                                     <rest xml:id="rest-0000001278761986" dur="4" />
@@ -457,18 +539,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002006122533" n="12">
                             <staff xml:id="staff-0000001301247886" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001402953851" dur="8" oct="3" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001905411216" dur="8" oct="3" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001106926047" dur="8" oct="3" pname="f" />
@@ -488,25 +574,29 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000539415091" n="13">
                             <staff xml:id="staff-0000000155085163" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001211608028" dur="8" oct="3" pname="c" />
                                             <note xml:id="note-0000001331598654" dur="8" oct="3" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000982538531" dur="8" oct="3" pname="e" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000103487512" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000002137550511" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000001481756451" dur="8" oct="3" pname="a" accid.ges="f" />
@@ -522,31 +612,39 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001263701703" n="14">
-                            <staff xml:id="staff-0000000156889322" n="1" visible="true">
+                            <staff xml:id="staff-0000000156889322" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001674651752" dur="8" oct="3" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000558486740" dur="8" oct="3" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000000573521780" dur="8" oct="3" pname="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000371122003" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000001012061616" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000590851385" dur="8" oct="3" pname="b" accid.ges="f" />
@@ -562,25 +660,29 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000355189963" n="15">
                             <staff xml:id="staff-0000001295812477" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000611227467" dur="8" oct="3" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001932659656" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000001696375764" dur="8" oct="3" pname="g" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000703873993" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000366756738" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000001489991612" dur="8" oct="4" pname="c" />
@@ -596,25 +698,29 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001858057008" n="16">
                             <staff xml:id="staff-0000001135171590" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001372611081" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000000642602746" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000000093668454" dur="8" oct="3" pname="a" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000856876503" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000341026170" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000000192566106" dur="8" oct="4" pname="d" accid.ges="f" />
@@ -624,15 +730,19 @@
                                     <note xml:id="note-0000001194843831" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000142862741" n="17">
-                            <staff xml:id="staff-0000000437249946" n="1" visible="true">
+                            <staff xml:id="staff-0000000437249946" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000000152253821" dur="4" oct="3" pname="d" accid.ges="f" />
                                     <note xml:id="note-0000000433809071" dur="4" oct="3" pname="e" accid.ges="f" />
@@ -643,14 +753,18 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                                <f>5</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                                <f>5</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000198373802" n="18">
                             <staff xml:id="staff-0000001315293905" n="1">
@@ -660,7 +774,7 @@
                                         <note xml:id="note-0000001184091996" dur="16" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001432238903" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000001140591675" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000658352510" dur="8" oct="3" pname="g" />
@@ -673,24 +787,36 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001832926414" n="19">
                             <staff xml:id="staff-0000000739927200" n="1">
@@ -700,7 +826,7 @@
                                         <note xml:id="note-0000001369047431" dur="16" oct="3" pname="b" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000551692444" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000001630181176" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000808315384" dur="8" oct="3" pname="a" accid.ges="f" />
@@ -713,40 +839,56 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002043015754" n="20">
-                            <staff xml:id="staff-0000001725279331" n="1" visible="true">
+                            <staff xml:id="staff-0000001725279331" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000001646584884" dots="1" dur="8" oct="4" pname="c" />
                                         <note xml:id="note-0000000572823524" dur="16" oct="4" pname="c" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001408830550" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000716144424" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001691841061" dur="8" oct="3" pname="b" accid.ges="f" />
@@ -762,24 +904,36 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001406646077" right="rptend" n="21">
                             <staff xml:id="staff-0000002053450868" n="1">
@@ -790,20 +944,28 @@
                                     <rest xml:id="rest-0000001740142267" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                                <f>4</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>3</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                                <f>4</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>3</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>3</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>3</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000597261657" left="rptstart" n="22">
                             <staff xml:id="staff-0000001874845446" n="1">
@@ -817,14 +979,14 @@
                                         <note xml:id="note-0000000035741857" dur="16" oct="4" pname="d" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001748275509" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001548389921" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000000400839510" dur="8" oct="3" pname="b" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001751709830" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000487029108" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000001780273034" dur="8" oct="3" pname="f" />
@@ -832,15 +994,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001265165097" n="23">
-                            <staff xml:id="staff-0000000449046634" n="1" visible="true">
+                            <staff xml:id="staff-0000000449046634" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000001961019312" dur="4" oct="3" pname="e">
                                         <accid xml:id="accid-0000000381362152" accid="n" />
@@ -850,14 +1016,14 @@
                                         <note xml:id="note-0000000740995863" dur="16" oct="4" pname="c" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001220093567" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001998496975" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000175771344" dur="8" oct="3" pname="a" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001936179870" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000000302857121" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000001156233177" dur="8" oct="3" pname="e">
@@ -867,18 +1033,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001132427062" n="24">
                             <staff xml:id="staff-0000000539290177" n="1">
@@ -892,14 +1066,14 @@
                                         <note xml:id="note-0000001016970177" dur="16" oct="4" pname="d" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001093853408" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001121219546" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001569366869" dur="8" oct="3" pname="b" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001452182480" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000001849208777" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000000196398644" dur="8" oct="3" pname="f" />
@@ -907,12 +1081,16 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002003382240" n="25">
                             <staff xml:id="staff-0000001784982246" n="1">
@@ -926,14 +1104,14 @@
                                         <note xml:id="note-0000000619675330" dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000726722782" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000000233779754" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000913286302" dur="8" oct="4" pname="c" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001259366236" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000769322476" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000305487653" dur="8" oct="3" pname="g" />
@@ -941,15 +1119,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000585450956" n="26">
-                            <staff xml:id="staff-0000001520585510" n="1" visible="true">
+                            <staff xml:id="staff-0000001520585510" n="1">
                                 <layer n="1">
                                     <clef xml:id="clef-0000000006469070" shape="C" line="4" />
                                     <beam>
@@ -961,14 +1143,14 @@
                                         <note xml:id="note-0000001662726481" dur="16" oct="4" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000002090992050" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000002133220329" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001889204956" dur="8" oct="4" pname="d" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000379911297" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000000173578436" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000001235242981" dur="8" oct="3" pname="a" accid.ges="f" />
@@ -989,7 +1171,7 @@
                                         <note xml:id="note-0000000988417644" dur="16" oct="4" pname="g" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001589782903" dur="8" oct="4" pname="g" />
                                             <note xml:id="note-0000000721248244" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000001950774980" dur="8" oct="4" pname="e">
@@ -998,7 +1180,7 @@
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001581094128" dur="8" oct="4" pname="e" />
                                             <note xml:id="note-0000000697273458" dur="8" oct="4" pname="d">
                                                 <accid xml:id="accid-0000000596445848" accid="n" />
@@ -1008,20 +1190,28 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6⃥</f>
-                                <f>4</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6⃥</f>
-                                <f>4</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000435002289" n="28">
                             <staff xml:id="staff-0000001436313935" n="1">
@@ -1037,7 +1227,7 @@
                                         <note xml:id="note-0000000323645816" dur="16" oct="3" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000380535913" dur="8" oct="3" pname="e">
                                                 <accid xml:id="accid-0000001022492943" accid="f" accid.ges="f" />
                                             </note>
@@ -1047,15 +1237,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000199158692" n="29">
-                            <staff xml:id="staff-0000002080068433" n="1" visible="true">
+                            <staff xml:id="staff-0000002080068433" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000000448645373" dur="4" oct="3" pname="d">
                                         <accid xml:id="accid-0000000379994166" accid="n" />
@@ -1069,7 +1263,7 @@
                                         <note xml:id="note-0000001258808355" dur="16" oct="3" pname="g" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000644502786" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000001979474159" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000000129260418" dur="8" oct="3" pname="f" />
@@ -1077,30 +1271,46 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001295016694" n="30">
                             <staff xml:id="staff-0000002057176652" n="1">
@@ -1115,7 +1325,7 @@
                                         <note xml:id="note-0000000185690831" dur="16" oct="3" pname="a" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000439805835" dur="8" oct="3" pname="g" />
                                             <note xml:id="note-0000000139183354" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000822543117" dur="8" oct="3" pname="g" />
@@ -1123,30 +1333,46 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000875647534" n="31">
                             <staff xml:id="staff-0000001560284680" n="1">
@@ -1161,7 +1387,7 @@
                                         <note xml:id="note-0000000540221563" dur="16" oct="3" pname="b" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001197170290" dur="8" oct="3" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000000667630686" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000486787014" dur="8" oct="3" pname="a" accid.ges="f" />
@@ -1169,33 +1395,49 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001573203733" n="32">
-                            <staff xml:id="staff-0000000840463772" n="1" visible="true">
+                            <staff xml:id="staff-0000000840463772" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000001660735528" dur="4" oct="3" pname="g" />
                                     <rest xml:id="rest-0000001915803149" dur="4" />
@@ -1210,24 +1452,32 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6⃥</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000744730060" n="33">
                             <staff xml:id="staff-0000000564951177" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000431454599" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000001357558103" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001820386971" dur="8" oct="4" pname="d" accid.ges="f" />
@@ -1244,18 +1494,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001121800967" n="34">
                             <staff xml:id="staff-0000000279008725" n="1">
@@ -1269,29 +1527,41 @@
                                     <note xml:id="note-0000001236971930" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                                <f>5</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>♮</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                                <f>5</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>♮</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>♮</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001066470152" n="35">
-                            <staff xml:id="staff-0000001168727038" n="1" visible="true">
+                            <staff xml:id="staff-0000001168727038" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000002110373411" dur="4" oct="2" pname="f" />
                                     <rest xml:id="rest-0000002057399513" dur="4" />
@@ -1307,23 +1577,27 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000493740974" n="36">
                             <staff xml:id="staff-0000000189812959" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000131008242" dur="8" oct="3" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000946872551" dur="8" oct="3" pname="c" />
                                             <note xml:id="note-0000001244212502" dur="8" oct="2" pname="b" accid.ges="f" />
                                         </tuplet>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001886402299" dur="8" oct="2" pname="a" accid.ges="f" />
                                             <note xml:id="note-0000001230466770" dur="8" oct="2" pname="g" />
                                             <note xml:id="note-0000000141414362" dur="8" oct="2" pname="f" />
@@ -1341,18 +1615,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000950606191" n="37">
                             <staff xml:id="staff-0000001111322519" n="1">
@@ -1371,29 +1653,33 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                                <f>4</f>
-                                <f>2</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                                <f>4</f>
-                                <f>2</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                    <f>2</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                    <f>2</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000765924639" n="38">
                             <staff xml:id="staff-0000001894559382" n="1">
                                 <layer n="1">
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000632941669" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000000101014088" dur="8" oct="3" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001878503193" dur="8" oct="3" pname="d" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001126853157" dur="8" oct="3" pname="c" />
                                             <note xml:id="note-0000001815577192" dur="8" oct="2" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000000143544403" dur="8" oct="2" pname="a" accid.ges="f" />
@@ -1409,27 +1695,39 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.750000"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.750000"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3.75">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3.75">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000669748467" n="39">
-                            <staff xml:id="staff-0000000752653766" n="1" visible="true">
+                            <staff xml:id="staff-0000000752653766" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000001872472768" dots="1" dur="8" oct="3" pname="g">
@@ -1442,14 +1740,14 @@
                                         <note xml:id="note-0000001638209245" dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001945739717" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001921625666" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000000255276741" dur="8" oct="4" pname="c" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001481403865" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001406701829" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000001507289985" dur="8" oct="3" pname="a" accid.ges="f" />
@@ -1471,14 +1769,14 @@
                                         <note xml:id="note-0000000337535526" dur="16" oct="4" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000621377404" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000001877271524" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001811105128" dur="8" oct="4" pname="d" accid.ges="f" />
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001177735813" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001327418319" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001359699423" dur="8" oct="3" pname="b" accid.ges="f" />
@@ -1486,15 +1784,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000493479060" n="41">
-                            <staff xml:id="staff-0000000700945596" n="1" visible="true">
+                            <staff xml:id="staff-0000000700945596" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000001961704320" dots="1" dur="8" oct="3" pname="b" accid.ges="f" />
@@ -1516,18 +1818,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000028673485" n="42">
                             <staff xml:id="staff-0000000963347790" n="1">
@@ -1544,7 +1854,7 @@
                                         <note xml:id="note-0000001270879930" dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001506535808" dur="8" oct="3" pname="f" />
                                             <note xml:id="note-0000001630928544" dur="8" oct="3" pname="g">
                                                 <accid xml:id="accid-0000001118238873" accid="f" accid.ges="f" />
@@ -1553,7 +1863,7 @@
                                         </tuplet>
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001599830061" dur="8" oct="3" pname="b" accid.ges="f" />
                                             <note xml:id="note-0000001096051983" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001709537092" dur="8" oct="4" pname="d" accid.ges="f" />
@@ -1561,24 +1871,36 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.750000"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.750000"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2.75">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2.75">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001397417464" n="43">
                             <staff xml:id="staff-0000001825286296" n="1">
@@ -1592,18 +1914,20 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001968799557" n="44">
-                            <staff xml:id="staff-0000001912242454" n="1" visible="true">
+                            <staff xml:id="staff-0000001912242454" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000001149761888" dots="1" dur="8" oct="4" pname="d" accid.ges="f" />
                                         <note xml:id="note-0000001086798519" dur="16" oct="4" pname="d" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001193259867" dur="8" oct="4" pname="c" />
                                             <note xml:id="note-0000001987182237" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001253800237" dur="8" oct="4" pname="c" />
@@ -1616,24 +1940,36 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002107539468" n="45">
                             <staff xml:id="staff-0000001735475179" n="1">
@@ -1643,7 +1979,7 @@
                                         <note xml:id="note-0000000229251359" dur="16" oct="4" pname="e" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000673673947" dur="8" oct="4" pname="d" accid.ges="f" />
                                             <note xml:id="note-0000001769207445" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001754965779" dur="8" oct="4" pname="d" accid.ges="f" />
@@ -1657,40 +1993,56 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001839542913" n="46">
-                            <staff xml:id="staff-0000000750753889" n="1" visible="true">
+                            <staff xml:id="staff-0000000750753889" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000000245364463" dots="1" dur="8" oct="4" pname="f" />
                                         <note xml:id="note-0000000558164187" dur="16" oct="4" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000907660354" dur="8" oct="4" pname="e" accid.ges="f" />
                                             <note xml:id="note-0000001564389404" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000000441469116" dur="8" oct="4" pname="e" accid.ges="f" />
@@ -1707,30 +2059,46 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="3"><fb>
-                                <f>7</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>7</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000601026268" n="47">
                             <staff xml:id="staff-0000000709502839" n="1">
@@ -1742,7 +2110,7 @@
                                         <note xml:id="note-0000000379012156" dur="16" oct="4" pname="g" accid.ges="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000032479832" dur="8" oct="4" pname="f" />
                                             <note xml:id="note-0000001384839922" dur="8" oct="4" pname="g" accid.ges="f" />
                                             <note xml:id="note-0000000646719708" dur="8" oct="4" pname="f" />
@@ -1753,18 +2121,26 @@
                                     <clef xml:id="clef-0000000352065921" shape="F" line="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000496458078" n="48">
                             <staff xml:id="staff-0000000025372567" n="1">
@@ -1778,7 +2154,7 @@
                                         <note xml:id="note-0000001519606037" dur="16" oct="3" pname="f" />
                                     </beam>
                                     <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001597687193" dur="8" oct="3" pname="g">
                                                 <accid xml:id="accid-0000001803722357" accid="f" accid.ges="f" />
                                             </note>
@@ -1792,15 +2168,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002102094302" n="49">
-                            <staff xml:id="staff-0000002086649027" n="1" visible="true">
+                            <staff xml:id="staff-0000002086649027" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000000101488548" dots="1" dur="8" oct="3" pname="d" accid.ges="f" />
@@ -1824,18 +2204,26 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>6</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="4"><fb>
-                                <f>6</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002144905428" right="rptend" n="50">
                             <staff xml:id="staff-0000001001903461" n="1">
@@ -1846,27 +2234,35 @@
                                     <rest xml:id="rest-0000001944516741" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                                <f>4</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>3</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="1"><fb>
-                                <f>6</f>
-                                <f>4</f>
-                            </fb></harm>
-                            <harm place='above' staff="1" tstamp="2"><fb>
-                                <f>3</f>
-                            </fb></harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>3</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place='above' staff="1" tstamp="2">
+                                <fb>
+                                    <f>3</f>
+                                </fb>
+                            </harm>
                         </measure>
-                      </section>
-                    </score>
-                    </mdiv>
-                    <mdiv>
-                      <score>
-                      <section>
+                    </section>
+                </score>
+            </mdiv>
+            <mdiv>
+                <score>
+                    <section>
                         <scoreDef key.pname="c" key.accid="s" key.mode="major">
                             <staffGrp>
                                 <staffDef n='1' lines='5' clef.shape="F" clef.line="4">
@@ -1876,1186 +2272,1186 @@
                             </staffGrp>
                         </scoreDef>
                         <section>
-                        <measure xml:id="measure-0000000764616467" n="1">
-                            <staff xml:id="staff-0000000744224883" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000884058691" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000001605100784" dur="16" oct="3" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001724281296" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000355160424" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001631327144" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001856661415" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000001358046671" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001845332529" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000067821288" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001326070991" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                            <dir place="above" staff="1" tstamp="1">
-                                <rend>Daſſelbige Prob-Stück, anders notiert.</rend>
-                            </dir>
-                        </measure>
-                        <measure xml:id="measure-0000001175975872" n="2">
-                            <staff xml:id="staff-0000000773605129" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000490626990" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001820393954" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000545138312" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001144025339" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001010761674" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000000734812381" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000815906461" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001581281604" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000921962667" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001178026361" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000502201132" n="3">
-                            <staff xml:id="staff-0000002082697360" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001812266927" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000292740818" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001768435736" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000000070780368" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000762380103" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000726035574" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000384789609" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000588607502" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000444443513" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000354030605" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001401738767" n="4">
-                            <staff xml:id="staff-0000000332747288" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000614143454" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000002107281195" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000223837613" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000001543961466" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001423033669" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000002007610777" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001571422491" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000380888921" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000273665314" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000411291759" dur="8" oct="4" pname="f" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001587219727" n="5">
-                            <staff xml:id="staff-0000001045443423" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000000827092506" dur="4" oct="3" pname="b" accid.ges="s" />
-                                    <note xml:id="note-0000001131837576" dur="4" oct="4" pname="c" accid.ges="s" />
-                                    <note xml:id="note-0000000899501536" dur="4" oct="3" pname="f" accid.ges="s" />
-                                    <note xml:id="note-0000000973228543" dur="4" oct="3" pname="g" accid.ges="s" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000475728550" n="6">
-                            <staff xml:id="staff-0000001642700673" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000000200721037" dur="4" oct="3" pname="c" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000000727470370" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000002062092263" dur="16" oct="3" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001764585190" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000642567921" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000797685594" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000006773408" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001479825673" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000110952716" n="7">
-                            <staff xml:id="staff-0000000872595296" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000000923504111" dur="4" oct="3" pname="a" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000000047263201" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000578108872" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000893797630" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000212633215" dur="16" oct="4" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001899134064" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000854120899" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001006319818" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001697363549" n="8">
-                            <staff xml:id="staff-0000002101548864" n="1" visible="true">
-                                <layer n="1">
-                                    <note xml:id="note-0000001604771821" dur="4" oct="3" pname="b" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001661445224" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001702804355" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001015499325" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000553057017" dur="16" oct="4" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000002047723069" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000122447062" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000716898980" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000757918812" n="9">
-                            <staff xml:id="staff-0000001472180762" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000002042344894" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000001077563975" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001066210210" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000000638499985" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <note xml:id="note-0000000635275966" dur="4" oct="3" pname="g">
-                                        <accid xml:id="accid-0000000479775676" accid="x" accid.ges="ss" />
-                                    </note>
-                                    <rest xml:id="rest-0000000573191109" dur="4" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000254425924" n="10">
-                            <staff xml:id="staff-0000000524876795" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001377789174" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001797478494" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001945802122" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001815390300" dur="16" oct="3" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000002066288632" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000981589083" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000002035426915" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001972618108" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000536199073" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000855700431" n="11">
-                            <staff xml:id="staff-0000000431803279" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000000459778729" dur="4" oct="2" pname="a" accid.ges="s" />
-                                    <rest xml:id="rest-0000001444228566" dur="4" />
-                                    <beam>
-                                        <note xml:id="note-0000001395905329" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001464963029" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000002050276005" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000639114449" dur="16" oct="2" pname="b" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000480765356" n="12">
-                            <staff xml:id="staff-0000000721436292" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001343549689" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000354499783" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001838667451" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001718483658" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001432289757" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001256191597" dots="1" dur="8" oct="2" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000582755696" dur="16" oct="2" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001533676369" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000000625672781" dur="16" oct="2" pname="a" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001902389584" n="13">
-                            <staff xml:id="staff-0000001713842588" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
-                                            <note xml:id="note-0000001413049993" dur="8" oct="2" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001850938123" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000002125083453" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000742928234" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000955178658" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000001451639501" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000000933988245" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001076723643" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000000111508441" dur="16" oct="2" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000947493869" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001533022994" dur="16" oct="2" pname="b" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001970287854" n="14">
-                            <staff xml:id="staff-0000000389379752" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001579077386" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001694252719" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000161005213" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000493714939" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000001572945288" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000000985250173" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000435833378" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000655330666" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000000083369891" dur="16" oct="2" pname="b" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001516012600" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000074266241" dur="16" oct="3" pname="c" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000737409305" n="15">
-                            <staff xml:id="staff-0000001663114451" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000987571877" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000586950636" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001196347627" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000000713796245" accid="x" accid.ges="ss" />
-                                            </note>
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000120342237" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001930281186" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000054685564" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000002115104359" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000464744899" dur="16" oct="3" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001186779428" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000046290007" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000002052761829" n="16">
-                            <staff xml:id="staff-0000000251515494" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001866586254" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000339408917" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000000801872723" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000000465945434" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000366288453" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000979237543" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000951554070" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000001381501838" dur="4" oct="3" pname="f" />
-                                    <note xml:id="note-0000000862439997" dur="4" oct="3" pname="g" accid.ges="s" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000909772819" n="17">
-                            <staff xml:id="staff-0000001749432153" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001892176289" dur="4" oct="3" pname="c" accid.ges="s" />
-                                    <note xml:id="note-0000000296743897" dur="4" oct="3" pname="d" accid.ges="s" />
-                                    <note xml:id="note-0000000314073485" dur="4" oct="2" pname="g" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000000003226096" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000321875728" dur="16" oct="2" pname="g" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000282283820" n="18">
-                            <staff xml:id="staff-0000000468308935" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000190922055" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000459531614" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000546264686" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000000091114487" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000000883388234" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000002032901722" dur="8" oct="3" pname="f" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000000565163580" dur="4" oct="3" pname="e" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001553076753" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001617199884" dur="16" oct="2" pname="a" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000381047696" n="19">
-                            <staff xml:id="staff-0000000594999269" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001177065973" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001132602233" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000286928020" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001117840192" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000259583450" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000001268307424" dur="4" oct="3" pname="f">
-                                        <accid xml:id="accid-0000001834538927" accid="x" accid.ges="ss" />
-                                    </note>
-                                    <beam>
-                                        <note xml:id="note-0000000775109616" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001688098786" dur="16" oct="2" pname="b" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000325841885" n="20">
-                            <staff xml:id="staff-0000001986942719" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001810516893" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001766510755" dur="16" oct="3" pname="b" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000304809956" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001316941531" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000793867271" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000680492399" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000924022597" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000401002294" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000000533186712" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000914137515" n="21">
-                            <staff xml:id="staff-0000000948774911" n="1" visible="true">
-                                <layer n="1">
-                                    <note xml:id="note-0000000158139362" dur="4" oct="4" pname="d" accid.ges="s" />
-                                    <note xml:id="note-0000001308814645" dur="4" oct="3" pname="d" accid.ges="s" />
-                                    <note xml:id="note-0000000100158580" dur="4" oct="3" pname="g" accid.ges="s" />
-                                    <rest xml:id="rest-0000001885827303" dur="4" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001848293689" n="22">
-                            <staff xml:id="staff-0000001942633863" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000062167710" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000245569379" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000002029909291" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000001500533507" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000428512572" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001046025130" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000002073817613" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001098755599" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001212357256" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000000929058141" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000000035242341" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001820696360" n="23">
-                            <staff xml:id="staff-0000000623497806" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001940637350" dur="4" oct="3" pname="d">
-                                        <accid xml:id="accid-0000002049854058" accid="x" accid.ges="ss" />
-                                    </note>
-                                    <beam>
-                                        <note xml:id="note-0000000718432221" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001468599576" dur="16" oct="3" pname="b" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000718030830" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000168420618" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000527410320" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001354247949" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000001458763312" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000000732527058" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001624645529" dur="8" oct="3" pname="d">
-                                                <accid xml:id="accid-0000000382031787" accid="x" accid.ges="ss" />
-                                            </note>
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000016163823" n="24">
-                            <staff xml:id="staff-0000000754375717" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001320844286" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000002108957504" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000002023944786" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000141229366" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000791791481" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001755937519" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001484855441" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001935429539" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001903316517" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000000247298444" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000001146828094" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001700473557" n="25">
-                            <staff xml:id="staff-0000000446371761" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000807377370" dots="1" dur="8" oct="3" pname="f">
-                                            <accid xml:id="accid-0000001966929740" accid="x" accid.ges="ss" />
+                            <measure xml:id="measure-0000000764616467" n="1">
+                                <staff xml:id="staff-0000000744224883" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000884058691" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001605100784" dur="16" oct="3" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001724281296" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000355160424" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001631327144" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000001856661415" dur="8" oct="3" pname="f" accid.ges="s" />
+                                                <note xml:id="note-0000001358046671" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001845332529" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000067821288" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001326070991" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                                <dir place="above" staff="1" tstamp="1">
+                                    <rend>Daſſelbige Prob-Stück, anders notiert.</rend>
+                                </dir>
+                            </measure>
+                            <measure xml:id="measure-0000001175975872" n="2">
+                                <staff xml:id="staff-0000000773605129" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000490626990" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001820393954" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000545138312" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001144025339" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001010761674" dur="8" oct="3" pname="f" accid.ges="s" />
+                                                <note xml:id="note-0000000734812381" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000000815906461" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001581281604" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000921962667" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001178026361" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000502201132" n="3">
+                                <staff xml:id="staff-0000002082697360" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001812266927" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000292740818" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001768435736" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000000070780368" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000762380103" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000000726035574" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000384789609" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000588607502" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000000444443513" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000354030605" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001401738767" n="4">
+                                <staff xml:id="staff-0000000332747288" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000614143454" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000002107281195" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000223837613" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001543961466" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001423033669" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000002007610777" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001571422491" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000380888921" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000273665314" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000411291759" dur="8" oct="4" pname="f" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001587219727" n="5">
+                                <staff xml:id="staff-0000001045443423" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000827092506" dur="4" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001131837576" dur="4" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000899501536" dur="4" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000000973228543" dur="4" oct="3" pname="g" accid.ges="s" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000475728550" n="6">
+                                <staff xml:id="staff-0000001642700673" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000200721037" dur="4" oct="3" pname="c" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000000727470370" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000002062092263" dur="16" oct="3" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001764585190" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000642567921" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000797685594" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000006773408" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001479825673" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000110952716" n="7">
+                                <staff xml:id="staff-0000000872595296" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000923504111" dur="4" oct="3" pname="a" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000000047263201" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000578108872" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000893797630" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000212633215" dur="16" oct="4" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001899134064" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000000854120899" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000001006319818" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001697363549" n="8">
+                                <staff xml:id="staff-0000002101548864" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001604771821" dur="4" oct="3" pname="b" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001661445224" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001702804355" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001015499325" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000553057017" dur="16" oct="4" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000002047723069" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000122447062" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000716898980" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000757918812" n="9">
+                                <staff xml:id="staff-0000001472180762" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000002042344894" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001077563975" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001066210210" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000638499985" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <note xml:id="note-0000000635275966" dur="4" oct="3" pname="g">
+                                            <accid xml:id="accid-0000000479775676" accid="x" accid.ges="ss" />
                                         </note>
-                                        <note xml:id="note-0000001322189417" dur="16" oct="3" pname="f" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000772400596" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000347027401" dur="16" oct="4" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000578604769" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001094782682" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001215084779" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001054617140" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000811275271" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000002069133086" dur="8" oct="3" pname="f" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000665625197" n="26">
-                            <staff xml:id="staff-0000001472329863" n="1">
-                                <layer n="1">
-                                    <clef xml:id="clef-0000000606241355" shape="C" line="4" />
-                                    <beam>
-                                        <note xml:id="note-0000000839981317" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000639573712" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001034560173" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001718280590" dur="16" oct="4" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000692716894" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000772923558" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001682644555" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000722533715" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000224176227" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001169793254" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000216118412" n="27">
-                            <staff xml:id="staff-0000001555329041" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001930689065" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001701135200" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001347753363" dots="1" dur="8" oct="4" pname="f">
-                                            <accid xml:id="accid-0000000172627577" accid="x" accid.ges="ss" />
+                                        <rest xml:id="rest-0000000573191109" dur="4" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000254425924" n="10">
+                                <staff xml:id="staff-0000000524876795" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001377789174" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001797478494" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001945802122" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001815390300" dur="16" oct="3" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000002066288632" dur="8" oct="3" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000981589083" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000002035426915" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001972618108" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000536199073" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000855700431" n="11">
+                                <staff xml:id="staff-0000000431803279" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000459778729" dur="4" oct="2" pname="a" accid.ges="s" />
+                                        <rest xml:id="rest-0000001444228566" dur="4" />
+                                        <beam>
+                                            <note xml:id="note-0000001395905329" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001464963029" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000002050276005" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000639114449" dur="16" oct="2" pname="b" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000480765356" n="12">
+                                <staff xml:id="staff-0000000721436292" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001343549689" dur="8" oct="3" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000000354499783" dur="8" oct="3" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000001838667451" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001718483658" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001432289757" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001256191597" dots="1" dur="8" oct="2" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000582755696" dur="16" oct="2" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001533676369" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000625672781" dur="16" oct="2" pname="a" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001902389584" n="13">
+                                <staff xml:id="staff-0000001713842588" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001413049993" dur="8" oct="2" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001850938123" dur="8" oct="3" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000002125083453" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000742928234" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000955178658" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000001451639501" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000000933988245" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001076723643" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000111508441" dur="16" oct="2" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000947493869" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001533022994" dur="16" oct="2" pname="b" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001970287854" n="14">
+                                <staff xml:id="staff-0000000389379752" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001579077386" dur="8" oct="3" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001694252719" dur="8" oct="3" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000161005213" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000493714939" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000001572945288" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000000985250173" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000000435833378" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000655330666" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000083369891" dur="16" oct="2" pname="b" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001516012600" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000074266241" dur="16" oct="3" pname="c" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000737409305" n="15">
+                                <staff xml:id="staff-0000001663114451" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000987571877" dur="8" oct="3" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000586950636" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000001196347627" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000000713796245" accid="x" accid.ges="ss" />
+                                                </note>
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000120342237" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000001930281186" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000054685564" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000002115104359" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000464744899" dur="16" oct="3" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001186779428" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000046290007" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000002052761829" n="16">
+                                <staff xml:id="staff-0000000251515494" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001866586254" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000339408917" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000000801872723" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000000465945434" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000366288453" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000979237543" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000951554070" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000001381501838" dur="4" oct="3" pname="f" />
+                                        <note xml:id="note-0000000862439997" dur="4" oct="3" pname="g" accid.ges="s" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000909772819" n="17">
+                                <staff xml:id="staff-0000001749432153" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001892176289" dur="4" oct="3" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000296743897" dur="4" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000314073485" dur="4" oct="2" pname="g" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000000003226096" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000321875728" dur="16" oct="2" pname="g" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000282283820" n="18">
+                                <staff xml:id="staff-0000000468308935" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000190922055" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000459531614" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000546264686" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000000091114487" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000000883388234" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000002032901722" dur="8" oct="3" pname="f" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000000565163580" dur="4" oct="3" pname="e" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001553076753" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001617199884" dur="16" oct="2" pname="a" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000381047696" n="19">
+                                <staff xml:id="staff-0000000594999269" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001177065973" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001132602233" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000286928020" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000001117840192" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000259583450" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000001268307424" dur="4" oct="3" pname="f">
+                                            <accid xml:id="accid-0000001834538927" accid="x" accid.ges="ss" />
                                         </note>
-                                        <note xml:id="note-0000001080325538" dur="16" oct="4" pname="f" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000124385170" dur="8" oct="4" pname="f" />
-                                            <note xml:id="note-0000001848050969" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000963473174" dur="8" oct="4" pname="d">
-                                                <accid xml:id="accid-0000001987635463" accid="x" accid.ges="ss" />
-                                            </note>
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001546081425" dur="8" oct="4" pname="d" />
-                                            <note xml:id="note-0000000113432273" dur="8" oct="4" pname="c">
-                                                <accid xml:id="accid-0000001785693073" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000001977064248" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000446436528" n="28">
-                            <staff xml:id="staff-0000001126986659" n="1" visible="true">
-                                <layer n="1">
-                                    <clef xml:id="clef-0000001321939318" shape="F" line="4" />
-                                    <rest xml:id="rest-0000001348294977" dur="4" />
-                                    <beam>
-                                        <note xml:id="note-0000000361225615" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001293769440" dur="16" oct="2" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001383830308" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001929750270" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000586067903" dur="8" oct="3" pname="d">
-                                                <accid xml:id="accid-0000000528836041" accid="s" accid.ges="s" />
-                                            </note>
-                                            <note xml:id="note-0000000107328038" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001055484596" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000094332557" n="29">
-                            <staff xml:id="staff-0000000974257480" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001531125584" dur="4" oct="3" pname="c">
-                                        <accid xml:id="accid-0000000059963860" accid="x" accid.ges="ss" />
-                                    </note>
-                                    <beam>
-                                        <note xml:id="note-0000001209947930" dots="1" dur="8" oct="3" pname="f">
-                                            <accid xml:id="accid-0000000920227066" accid="x" accid.ges="ss" />
+                                        <beam>
+                                            <note xml:id="note-0000000775109616" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001688098786" dur="16" oct="2" pname="b" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000325841885" n="20">
+                                <staff xml:id="staff-0000001986942719" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001810516893" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001766510755" dur="16" oct="3" pname="b" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000304809956" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000001316941531" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000793867271" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000680492399" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000924022597" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000401002294" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000533186712" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000914137515" n="21">
+                                <staff xml:id="staff-0000000948774911" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000158139362" dur="4" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001308814645" dur="4" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000100158580" dur="4" oct="3" pname="g" accid.ges="s" />
+                                        <rest xml:id="rest-0000001885827303" dur="4" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001848293689" n="22">
+                                <staff xml:id="staff-0000001942633863" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000062167710" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000245569379" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000002029909291" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001500533507" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000428512572" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001046025130" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000002073817613" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001098755599" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000001212357256" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000000929058141" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000000035242341" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001820696360" n="23">
+                                <staff xml:id="staff-0000000623497806" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001940637350" dur="4" oct="3" pname="d">
+                                            <accid xml:id="accid-0000002049854058" accid="x" accid.ges="ss" />
                                         </note>
-                                        <note xml:id="note-0000001326635735" dur="16" oct="2" pname="f">
-                                            <accid xml:id="accid-0000001918672053" accid="x" accid.ges="ss" />
-                                        </note>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000377147855" dots="1" dur="8" oct="3" pname="f" />
-                                        <note xml:id="note-0000001400224495" dur="16" oct="3" pname="f" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001603915126" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000002055679497" dur="8" oct="3" pname="f" />
-                                            <note xml:id="note-0000001103306706" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001711379764" n="30">
-                            <staff xml:id="staff-0000000536493021" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000000260688999" dur="4" oct="3" pname="d" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001042429617" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000439405782" dur="16" oct="2" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000655196646" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000186114407" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000002038348578" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000002055151772" accid="x" accid.ges="ss" />
+                                        <beam>
+                                            <note xml:id="note-0000000718432221" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001468599576" dur="16" oct="3" pname="b" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000718030830" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000168420618" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000527410320" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001354247949" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000001458763312" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000000732527058" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000001624645529" dur="8" oct="3" pname="d">
+                                                    <accid xml:id="accid-0000000382031787" accid="x" accid.ges="ss" />
+                                                </note>
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000016163823" n="24">
+                                <staff xml:id="staff-0000000754375717" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001320844286" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000002108957504" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000002023944786" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000141229366" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000791791481" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001755937519" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001484855441" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001935429539" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000001903316517" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000000247298444" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000001146828094" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001700473557" n="25">
+                                <staff xml:id="staff-0000000446371761" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000807377370" dots="1" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000001966929740" accid="x" accid.ges="ss" />
                                             </note>
-                                            <note xml:id="note-0000001558317993" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001061988077" dur="8" oct="3" pname="f" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000808012465" n="31">
-                            <staff xml:id="staff-0000001403656205" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001101808123" dur="4" oct="3" pname="e" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001315618807" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000000766081254" dur="16" oct="2" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000002073427895" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000000198633226" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001720223442" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000402121155" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000717369997" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001097449125" n="32">
-                            <staff xml:id="staff-0000000920741306" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000000566368460" dur="4" oct="3" pname="f">
-                                        <accid xml:id="accid-0000000466149794" accid="x" accid.ges="ss" />
-                                    </note>
-                                    <rest xml:id="rest-0000000155881601" dur="4" />
-                                    <clef xml:id="clef-0000000245135638" shape="C" line="4" />
-                                    <beam>
-                                        <note xml:id="note-0000001913864534" dots="1" dur="8" oct="4" pname="f">
-                                            <accid xml:id="accid-0000001728538115" accid="x" accid.ges="ss" />
-                                        </note>
-                                        <note xml:id="note-0000000922072168" dur="16" oct="3" pname="b" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001578745991" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001616316323" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000366245153" n="33">
-                            <staff xml:id="staff-0000000606057497" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000259490996" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000002002928631" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000838724541" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000757872116" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001486794630" dur="16" oct="3" pname="b" accid.ges="s" />
-                                    </beam>
-                                    <note xml:id="note-0000001526138537" dur="4" oct="3" pname="e" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001416601157" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000002021256189" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001025439776" n="34">
-                            <staff xml:id="staff-0000001272086118" n="1">
-                                <layer n="1">
-                                    <clef xml:id="clef-0000000495369573" shape="F" line="4" />
-                                    <note xml:id="note-0000001380983122" dur="4" oct="3" pname="d">
-                                        <accid xml:id="accid-0000001601911783" accid="x" accid.ges="ss" />
-                                    </note>
-                                    <note xml:id="note-0000001267176725" dur="4" oct="3" pname="e" accid.ges="s" />
-                                    <note xml:id="note-0000000026233512" dur="4" oct="2" pname="a" accid.ges="s" />
-                                    <note xml:id="note-0000001548371982" dur="4" oct="2" pname="b" accid.ges="s" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001698329280" n="35">
-                            <staff xml:id="staff-0000000707570821" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001673846375" dur="4" oct="2" pname="e" accid.ges="s" />
-                                    <rest xml:id="rest-0000000691730473" dur="4" />
-                                    <beam>
-                                        <note xml:id="note-0000000655991420" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000025270262" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001627551052" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001030226750" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000407784154" n="36">
-                            <staff xml:id="staff-0000001198365918" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
-                                            <note xml:id="note-0000000286175450" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001138229582" dur="8" oct="2" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000255588969" dur="8" oct="2" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
-                                            <note xml:id="note-0000001547989606" dur="8" oct="2" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000532008841" dur="8" oct="2" pname="f">
-                                                <accid xml:id="accid-0000000496633418" accid="x" accid.ges="ss" />
+                                            <note xml:id="note-0000001322189417" dur="16" oct="3" pname="f" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000772400596" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000347027401" dur="16" oct="4" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000578604769" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000001094782682" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001215084779" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001054617140" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000811275271" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000002069133086" dur="8" oct="3" pname="f" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000665625197" n="26">
+                                <staff xml:id="staff-0000001472329863" n="1">
+                                    <layer n="1">
+                                        <clef xml:id="clef-0000000606241355" shape="C" line="4" />
+                                        <beam>
+                                            <note xml:id="note-0000000839981317" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000639573712" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001034560173" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001718280590" dur="16" oct="4" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000692716894" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000772923558" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000001682644555" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000722533715" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000224176227" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000001169793254" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000216118412" n="27">
+                                <staff xml:id="staff-0000001555329041" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001930689065" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001701135200" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001347753363" dots="1" dur="8" oct="4" pname="f">
+                                                <accid xml:id="accid-0000000172627577" accid="x" accid.ges="ss" />
                                             </note>
-                                            <note xml:id="note-0000002028184132" dur="8" oct="2" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000195581117" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000001451064943" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001309429970" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000922692405" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001190627964" n="37">
-                            <staff xml:id="staff-0000002068558781" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001446244714" dur="4" oct="3" pname="d" accid.ges="s" />
-                                    <note xml:id="note-0000002083100293" dur="4" oct="2" pname="g" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001022764850" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000001014365471" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000623937958" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000000009225814" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000409265327" n="38">
-                            <staff xml:id="staff-0000001398219271" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001241256177" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001996301513" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000211198258" dur="8" oct="3" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="above" bracket.place="above" bracket.visible="false">
-                                            <note xml:id="note-0000002091755926" dur="8" oct="2" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001711341011" dur="8" oct="2" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001819920353" dur="8" oct="2" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001055936890" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000000333896810" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001088590631" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000789863280" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001938791443" n="39">
-                            <staff xml:id="staff-0000000982976717" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000002025763844" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000001967571622" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001716982414" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001905305510" dur="16" oct="4" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000969164854" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000927242269" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001956144303" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000482708927" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000267064325" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001511524595" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000479101824" n="40">
-                            <staff xml:id="staff-0000000215083342" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001548530569" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000053717964" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <clef xml:id="clef-0000001695362886" shape="C" line="4" />
-                                    <beam>
-                                        <note xml:id="note-0000001605504993" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000001846566269" dur="16" oct="4" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000744873548" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000077924150" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000228220375" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000802569028" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001156562344" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000685089000" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001024740628" n="41">
-                            <staff xml:id="staff-0000000039306765" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000002098251702" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001198772305" dur="16" oct="3" pname="a" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001769736010" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000000732755769" dur="16" oct="4" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000918972868" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000002062069861" dur="16" oct="3" pname="b" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001712854170" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000868272524" dur="16" oct="4" pname="e" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000090150956" n="42">
-                            <staff xml:id="staff-0000000254065927" n="1">
-                                <layer n="1">
-                                    <clef xml:id="clef-0000001498375363" shape="F" line="4" />
-                                    <beam>
-                                        <note xml:id="note-0000000069278807" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000001611834371" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001801830825" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000764209808" dur="16" oct="4" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001573959307" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000338646465" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000000467148891" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000001324864289" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001243550684" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001445800829" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001337206176" n="43">
-                            <staff xml:id="staff-0000000780538774" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001272325229" dur="4" oct="3" pname="g" accid.ges="s" />
-                                    <note xml:id="note-0000001948255782" dur="4" oct="2" pname="g" accid.ges="s" />
-                                    <rest xml:id="rest-0000000055185116" dur="4" />
-                                    <beam>
-                                        <note xml:id="note-0000000156498351" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000025314840" dur="16" oct="3" pname="c" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001798722409" n="44">
-                            <staff xml:id="staff-0000000741600718" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001751268327" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000001919417306" dur="16" oct="4" pname="c" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000692265492" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001269329189" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000002097969950" dur="8" oct="3" pname="b" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000001177796869" dur="4" oct="3" pname="a" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000001004535706" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001691716907" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000595461325" n="45">
-                            <staff xml:id="staff-0000001544499059" n="1" visible="true">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000514812354" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000292053225" dur="16" oct="4" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000238857026" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000534650888" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000491883760" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000000130401844" dur="4" oct="3" pname="b" accid.ges="s" />
-                                    <clef xml:id="clef-0000000144881338" shape="C" line="4" />
-                                    <beam>
-                                        <note xml:id="note-0000000638050957" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000500660317" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001589269306" n="46">
-                            <staff xml:id="staff-0000002128681460" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000636702072" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000488657468" dur="16" oct="4" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000469756257" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000077367046" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000002004205928" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000001003481019" dur="4" oct="4" pname="c" accid.ges="s" />
-                                    <beam>
-                                        <note xml:id="note-0000000427559261" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000001115317562" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001418854709" n="47">
-                            <staff xml:id="staff-0000001300880243" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000001445702015" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000002019398822" dur="16" oct="4" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000000619381560" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000306508323" dur="8" oct="4" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000002109156844" dur="8" oct="4" pname="e" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <note xml:id="note-0000001671412810" dur="4" oct="4" pname="d" accid.ges="s" />
-                                    <note xml:id="note-0000001095742329" dur="4" oct="3" pname="g" accid.ges="s" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000434807678" n="48">
-                            <staff xml:id="staff-0000000899922947" n="1" visible="true">
-                                <layer n="1">
-                                    <clef xml:id="clef-0000000049326528" shape="F" line="4" />
-                                    <beam>
-                                        <note xml:id="note-0000001044404730" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000206132670" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001878887937" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000001846251732" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.place="below" bracket.place="below" bracket.visible="false">
-                                            <note xml:id="note-0000002121513331" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000000385024514" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000002108317258" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000018165466" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000163000213" dur="16" oct="3" pname="g" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000000924016691" n="49">
-                            <staff xml:id="staff-0000000722337749" n="1">
-                                <layer n="1">
-                                    <beam>
-                                        <note xml:id="note-0000000475692573" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000089131372" dur="16" oct="3" pname="d" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000000436966555" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000958915602" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000001420598158" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000860637944" dur="16" oct="3" pname="e" accid.ges="s" />
-                                    </beam>
-                                    <beam>
-                                        <note xml:id="note-0000002007151947" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000000640368958" dur="16" oct="3" pname="f" accid.ges="s" />
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure xml:id="measure-0000001975975990" right="rptend" n="50">
-                            <staff xml:id="staff-0000000354552036" n="1">
-                                <layer n="1">
-                                    <note xml:id="note-0000001790422992" dur="4" oct="3" pname="g" accid.ges="s" />
-                                    <note xml:id="note-0000000411154624" dur="4" oct="2" pname="g" accid.ges="s" />
-                                    <note xml:id="note-0000000098253069" dur="4" oct="3" pname="c" accid.ges="s" />
-                                    <rest xml:id="rest-0000002090582923" dur="4" />
-                                </layer>
-                            </staff>
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
-</mei>
+                                            <note xml:id="note-0000001080325538" dur="16" oct="4" pname="f" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000124385170" dur="8" oct="4" pname="f" />
+                                                <note xml:id="note-0000001848050969" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000963473174" dur="8" oct="4" pname="d">
+                                                    <accid xml:id="accid-0000001987635463" accid="x" accid.ges="ss" />
+                                                </note>
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001546081425" dur="8" oct="4" pname="d" />
+                                                <note xml:id="note-0000000113432273" dur="8" oct="4" pname="c">
+                                                    <accid xml:id="accid-0000001785693073" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000001977064248" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000446436528" n="28">
+                                <staff xml:id="staff-0000001126986659" n="1">
+                                    <layer n="1">
+                                        <clef xml:id="clef-0000001321939318" shape="F" line="4" />
+                                        <rest xml:id="rest-0000001348294977" dur="4" />
+                                        <beam>
+                                            <note xml:id="note-0000000361225615" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001293769440" dur="16" oct="2" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001383830308" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001929750270" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000586067903" dur="8" oct="3" pname="d">
+                                                    <accid xml:id="accid-0000000528836041" accid="s" accid.ges="s" />
+                                                </note>
+                                                <note xml:id="note-0000000107328038" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000001055484596" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000094332557" n="29">
+                                <staff xml:id="staff-0000000974257480" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001531125584" dur="4" oct="3" pname="c">
+                                            <accid xml:id="accid-0000000059963860" accid="x" accid.ges="ss" />
+                                        </note>
+                                        <beam>
+                                            <note xml:id="note-0000001209947930" dots="1" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000000920227066" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000001326635735" dur="16" oct="2" pname="f">
+                                                <accid xml:id="accid-0000001918672053" accid="x" accid.ges="ss" />
+                                            </note>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000377147855" dots="1" dur="8" oct="3" pname="f" />
+                                            <note xml:id="note-0000001400224495" dur="16" oct="3" pname="f" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001603915126" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000002055679497" dur="8" oct="3" pname="f" />
+                                                <note xml:id="note-0000001103306706" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001711379764" n="30">
+                                <staff xml:id="staff-0000000536493021" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000260688999" dur="4" oct="3" pname="d" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001042429617" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000439405782" dur="16" oct="2" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000655196646" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000186114407" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000002038348578" dur="8" oct="3" pname="f">
+                                                    <accid xml:id="accid-0000002055151772" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000001558317993" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000001061988077" dur="8" oct="3" pname="f" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000808012465" n="31">
+                                <staff xml:id="staff-0000001403656205" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001101808123" dur="4" oct="3" pname="e" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001315618807" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000766081254" dur="16" oct="2" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000002073427895" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000198633226" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001720223442" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000000402121155" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000000717369997" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001097449125" n="32">
+                                <staff xml:id="staff-0000000920741306" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000000566368460" dur="4" oct="3" pname="f">
+                                            <accid xml:id="accid-0000000466149794" accid="x" accid.ges="ss" />
+                                        </note>
+                                        <rest xml:id="rest-0000000155881601" dur="4" />
+                                        <clef xml:id="clef-0000000245135638" shape="C" line="4" />
+                                        <beam>
+                                            <note xml:id="note-0000001913864534" dots="1" dur="8" oct="4" pname="f">
+                                                <accid xml:id="accid-0000001728538115" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000000922072168" dur="16" oct="3" pname="b" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001578745991" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001616316323" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000366245153" n="33">
+                                <staff xml:id="staff-0000000606057497" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000259490996" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000002002928631" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000838724541" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000757872116" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001486794630" dur="16" oct="3" pname="b" accid.ges="s" />
+                                        </beam>
+                                        <note xml:id="note-0000001526138537" dur="4" oct="3" pname="e" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001416601157" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000002021256189" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001025439776" n="34">
+                                <staff xml:id="staff-0000001272086118" n="1">
+                                    <layer n="1">
+                                        <clef xml:id="clef-0000000495369573" shape="F" line="4" />
+                                        <note xml:id="note-0000001380983122" dur="4" oct="3" pname="d">
+                                            <accid xml:id="accid-0000001601911783" accid="x" accid.ges="ss" />
+                                        </note>
+                                        <note xml:id="note-0000001267176725" dur="4" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000026233512" dur="4" oct="2" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001548371982" dur="4" oct="2" pname="b" accid.ges="s" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001698329280" n="35">
+                                <staff xml:id="staff-0000000707570821" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001673846375" dur="4" oct="2" pname="e" accid.ges="s" />
+                                        <rest xml:id="rest-0000000691730473" dur="4" />
+                                        <beam>
+                                            <note xml:id="note-0000000655991420" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000025270262" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001627551052" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001030226750" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000407784154" n="36">
+                                <staff xml:id="staff-0000001198365918" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000286175450" dur="8" oct="3" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001138229582" dur="8" oct="2" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000255588969" dur="8" oct="2" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001547989606" dur="8" oct="2" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000000532008841" dur="8" oct="2" pname="f">
+                                                    <accid xml:id="accid-0000000496633418" accid="x" accid.ges="ss" />
+                                                </note>
+                                                <note xml:id="note-0000002028184132" dur="8" oct="2" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000195581117" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000001451064943" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001309429970" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000922692405" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001190627964" n="37">
+                                <staff xml:id="staff-0000002068558781" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001446244714" dur="4" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000002083100293" dur="4" oct="2" pname="g" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001022764850" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001014365471" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000623937958" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000000009225814" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000409265327" n="38">
+                                <staff xml:id="staff-0000001398219271" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001241256177" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000001996301513" dur="8" oct="3" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000211198258" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000002091755926" dur="8" oct="2" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001711341011" dur="8" oct="2" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000001819920353" dur="8" oct="2" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001055936890" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000333896810" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001088590631" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000789863280" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001938791443" n="39">
+                                <staff xml:id="staff-0000000982976717" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000002025763844" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000001967571622" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001716982414" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001905305510" dur="16" oct="4" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000969164854" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000927242269" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001956144303" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000482708927" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000267064325" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000001511524595" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000479101824" n="40">
+                                <staff xml:id="staff-0000000215083342" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001548530569" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000053717964" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <clef xml:id="clef-0000001695362886" shape="C" line="4" />
+                                        <beam>
+                                            <note xml:id="note-0000001605504993" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001846566269" dur="16" oct="4" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000744873548" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000077924150" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000228220375" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000802569028" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000001156562344" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000000685089000" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001024740628" n="41">
+                                <staff xml:id="staff-0000000039306765" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000002098251702" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001198772305" dur="16" oct="3" pname="a" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001769736010" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000000732755769" dur="16" oct="4" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000918972868" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000002062069861" dur="16" oct="3" pname="b" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001712854170" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000868272524" dur="16" oct="4" pname="e" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000090150956" n="42">
+                                <staff xml:id="staff-0000000254065927" n="1">
+                                    <layer n="1">
+                                        <clef xml:id="clef-0000001498375363" shape="F" line="4" />
+                                        <beam>
+                                            <note xml:id="note-0000000069278807" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000001611834371" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001801830825" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000764209808" dur="16" oct="4" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001573959307" dur="8" oct="3" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000338646465" dur="8" oct="3" pname="f" accid.ges="s" />
+                                                <note xml:id="note-0000000467148891" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000001324864289" dur="8" oct="3" pname="a" accid.ges="s" />
+                                                <note xml:id="note-0000001243550684" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001445800829" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001337206176" n="43">
+                                <staff xml:id="staff-0000000780538774" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001272325229" dur="4" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000001948255782" dur="4" oct="2" pname="g" accid.ges="s" />
+                                        <rest xml:id="rest-0000000055185116" dur="4" />
+                                        <beam>
+                                            <note xml:id="note-0000000156498351" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000025314840" dur="16" oct="3" pname="c" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001798722409" n="44">
+                                <staff xml:id="staff-0000000741600718" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001751268327" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001919417306" dur="16" oct="4" pname="c" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000692265492" dur="8" oct="3" pname="b" accid.ges="s" />
+                                                <note xml:id="note-0000001269329189" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000002097969950" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000001177796869" dur="4" oct="3" pname="a" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000001004535706" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001691716907" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000595461325" n="45">
+                                <staff xml:id="staff-0000001544499059" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000514812354" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000292053225" dur="16" oct="4" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000238857026" dur="8" oct="4" pname="c" accid.ges="s" />
+                                                <note xml:id="note-0000000534650888" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000491883760" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000000130401844" dur="4" oct="3" pname="b" accid.ges="s" />
+                                        <clef xml:id="clef-0000000144881338" shape="C" line="4" />
+                                        <beam>
+                                            <note xml:id="note-0000000638050957" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000500660317" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001589269306" n="46">
+                                <staff xml:id="staff-0000002128681460" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000636702072" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000488657468" dur="16" oct="4" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000469756257" dur="8" oct="4" pname="d" accid.ges="s" />
+                                                <note xml:id="note-0000000077367046" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000002004205928" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000001003481019" dur="4" oct="4" pname="c" accid.ges="s" />
+                                        <beam>
+                                            <note xml:id="note-0000000427559261" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000001115317562" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001418854709" n="47">
+                                <staff xml:id="staff-0000001300880243" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000001445702015" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000002019398822" dur="16" oct="4" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000000619381560" dur="8" oct="4" pname="e" accid.ges="s" />
+                                                <note xml:id="note-0000000306508323" dur="8" oct="4" pname="f" accid.ges="s" />
+                                                <note xml:id="note-0000002109156844" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <note xml:id="note-0000001671412810" dur="4" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001095742329" dur="4" oct="3" pname="g" accid.ges="s" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000434807678" n="48">
+                                <staff xml:id="staff-0000000899922947" n="1">
+                                    <layer n="1">
+                                        <clef xml:id="clef-0000000049326528" shape="F" line="4" />
+                                        <beam>
+                                            <note xml:id="note-0000001044404730" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000206132670" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001878887937" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001846251732" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                                <note xml:id="note-0000002121513331" dur="8" oct="3" pname="f" accid.ges="s" />
+                                                <note xml:id="note-0000000385024514" dur="8" oct="3" pname="g" accid.ges="s" />
+                                                <note xml:id="note-0000002108317258" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            </tuplet>
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000018165466" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000163000213" dur="16" oct="3" pname="g" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000000924016691" n="49">
+                                <staff xml:id="staff-0000000722337749" n="1">
+                                    <layer n="1">
+                                        <beam>
+                                            <note xml:id="note-0000000475692573" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000089131372" dur="16" oct="3" pname="d" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000000436966555" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000958915602" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000001420598158" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000860637944" dur="16" oct="3" pname="e" accid.ges="s" />
+                                        </beam>
+                                        <beam>
+                                            <note xml:id="note-0000002007151947" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000640368958" dur="16" oct="3" pname="f" accid.ges="s" />
+                                        </beam>
+                                    </layer>
+                                </staff>
+                            </measure>
+                            <measure xml:id="measure-0000001975975990" right="rptend" n="50">
+                                <staff xml:id="staff-0000000354552036" n="1">
+                                    <layer n="1">
+                                        <note xml:id="note-0000001790422992" dur="4" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000411154624" dur="4" oct="2" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000098253069" dur="4" oct="3" pname="c" accid.ges="s" />
+                                        <rest xml:id="rest-0000002090582923" dur="4" />
+                                    </layer>
+                                </staff>
+                            </measure>
+                        </section>
+                    </score>
+                </mdiv>
+            </body>
+        </music>
+    </mei>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -64,10 +64,11 @@
         <body>
             <mdiv>
                 <score>
-                    <scoreDef>
+                    <scoreDef key.pname="d" key.accid="f" key.mode="major">
                         <staffGrp>
-                            <staffDef n='1' lines='5' clef.shape="F" clef.line="4" meter.count="4" meter.unit="4" meter.sym="common">
+                            <staffDef n='1' lines='5' clef.shape="F" clef.line="4">
                                 <keySig mode="major" sig="4f" />
+                                <meterSig count="4" unit="4" sym="common" />
                             </staffDef>
                         </staffGrp>
                     </scoreDef>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="4.0.0">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1861,10 +1861,22 @@
                             </fb></harm>
                         </measure>
                       </section>
+                    </score>
+                    </mdiv>
+                    <mdiv>
+                      <score>
                       <section>
-                        <scoreDef xml:id="scoredef-0000000255279287" key.mode="major" key.sig="7s" />
+                        <scoreDef key.pname="c" key.accid="s" key.mode="major">
+                            <staffGrp>
+                                <staffDef n='1' lines='5' clef.shape="F" clef.line="4">
+                                    <keySig mode="major" sig="7s" />
+                                    <meterSig count="4" unit="4" sym="common" />
+                                </staffDef>
+                            </staffGrp>
+                        </scoreDef>
+                        <section>
                         <measure xml:id="measure-0000000764616467" n="1">
-                            <staff xml:id="staff-0000000744224883" n="1" visible="true">
+                            <staff xml:id="staff-0000000744224883" n="1">
                                 <layer n="1">
                                     <beam>
                                         <note xml:id="note-0000000884058691" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1819,8 +1819,6 @@
                                             <note xml:id="note-0000001856661415" dur="8" oct="3" pname="f" accid.ges="s" />
                                             <note xml:id="note-0000001358046671" dur="8" oct="3" pname="g" accid.ges="s" />
                                         </tuplet>
-                                    </beam>
-                                    <beam>
                                         <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001845332529" dur="8" oct="3" pname="a" accid.ges="s" />
                                             <note xml:id="note-0000000067821288" dur="8" oct="3" pname="b" accid.ges="s" />
@@ -1829,6 +1827,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001175975872" n="2">
                             <staff xml:id="staff-0000000773605129" n="1">
@@ -1847,8 +1855,6 @@
                                             <note xml:id="note-0000000734812381" dur="8" oct="3" pname="g" accid.ges="s" />
                                             <note xml:id="note-0000000815906461" dur="8" oct="3" pname="a" accid.ges="s" />
                                         </tuplet>
-                                    </beam>
-                                    <beam>
                                         <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001581281604" dur="8" oct="3" pname="b" accid.ges="s" />
                                             <note xml:id="note-0000000921962667" dur="8" oct="4" pname="c" accid.ges="s" />
@@ -1857,6 +1863,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000502201132" n="3">
                             <staff xml:id="staff-0000002082697360" n="1">
@@ -1875,8 +1891,6 @@
                                             <note xml:id="note-0000000726035574" dur="8" oct="3" pname="a" accid.ges="s" />
                                             <note xml:id="note-0000000384789609" dur="8" oct="3" pname="b" accid.ges="s" />
                                         </tuplet>
-                                    </beam>
-                                    <beam>
                                         <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000588607502" dur="8" oct="4" pname="c" accid.ges="s" />
                                             <note xml:id="note-0000000444443513" dur="8" oct="4" pname="d" accid.ges="s" />
@@ -1885,6 +1899,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001401738767" n="4">
                             <staff xml:id="staff-0000000332747288" n="1">
@@ -1902,10 +1921,6 @@
                                             <note xml:id="note-0000001423033669" dur="8" oct="3" pname="a" accid.ges="s" />
                                             <note xml:id="note-0000002007610777" dur="8" oct="3" pname="b" accid.ges="s" />
                                             <note xml:id="note-0000001571422491" dur="8" oct="4" pname="c" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000380888921" dur="8" oct="4" pname="d" accid.ges="s" />
                                             <note xml:id="note-0000000273665314" dur="8" oct="4" pname="e" accid.ges="s" />
                                             <note xml:id="note-0000000411291759" dur="8" oct="4" pname="f" accid.ges="s" />
@@ -1913,6 +1928,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001587219727" n="5">
                             <staff xml:id="staff-0000001045443423" n="1">
@@ -1923,6 +1943,17 @@
                                     <note xml:id="note-0000000973228543" dur="4" oct="3" pname="g" accid.ges="s" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000475728550" n="6">
                             <staff xml:id="staff-0000001642700673" n="1">
@@ -1945,6 +1976,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000110952716" n="7">
                             <staff xml:id="staff-0000000872595296" n="1">
@@ -1967,6 +2003,26 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001697363549" n="8">
                             <staff xml:id="staff-0000002101548864" n="1">
@@ -1989,6 +2045,23 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                    <f>2</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000757918812" n="9">
                             <staff xml:id="staff-0000001472180762" n="1">
@@ -2007,6 +2080,16 @@
                                     <rest xml:id="rest-0000000573191109" dur="4" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000254425924" n="10">
                             <staff xml:id="staff-0000000524876795" n="1">
@@ -2032,6 +2115,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000855700431" n="11">
                             <staff xml:id="staff-0000000431803279" n="1">
@@ -2048,6 +2141,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000480765356" n="12">
                             <staff xml:id="staff-0000000721436292" n="1">
@@ -2073,6 +2171,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001902389584" n="13">
                             <staff xml:id="staff-0000001713842588" n="1">
@@ -2103,6 +2211,21 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001970287854" n="14">
                             <staff xml:id="staff-0000000389379752" n="1">
@@ -2133,6 +2256,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000737409305" n="15">
                             <staff xml:id="staff-0000001663114451" n="1">
@@ -2163,6 +2291,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002052761829" n="16">
                             <staff xml:id="staff-0000000251515494" n="1">
@@ -2187,6 +2320,16 @@
                                     <note xml:id="note-0000000862439997" dur="4" oct="3" pname="g" accid.ges="s" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000909772819" n="17">
                             <staff xml:id="staff-0000001749432153" n="1">
@@ -2200,6 +2343,17 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000282283820" n="18">
                             <staff xml:id="staff-0000000468308935" n="1">
@@ -2224,6 +2378,21 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000381047696" n="19">
                             <staff xml:id="staff-0000000594999269" n="1">
@@ -2248,6 +2417,28 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <supplied resp="#rettinghaus">
+                                <harm place="above" staff="1" tstamp="1">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000325841885" n="20">
                             <staff xml:id="staff-0000001986942719" n="1">
@@ -2273,8 +2464,25 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <supplied resp="#rettinghaus">
+                                <harm place="above" staff="1" tstamp="4">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
-                        <measure xml:id="measure-0000000914137515" n="21">
+                        <measure xml:id="measure-0000000914137515" right="rptend" n="21">
                             <staff xml:id="staff-0000000948774911" n="1">
                                 <layer n="1">
                                     <note xml:id="note-0000000158139362" dur="4" oct="4" pname="d" accid.ges="s" />
@@ -2283,8 +2491,20 @@
                                     <rest xml:id="rest-0000001885827303" dur="4" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f />
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
                         </measure>
-                        <measure xml:id="measure-0000001848293689" n="22">
+                        <measure xml:id="measure-0000001848293689" left="rptstart" n="22">
                             <staff xml:id="staff-0000001942633863" n="1">
                                 <layer n="1">
                                     <beam>
@@ -2313,6 +2533,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001820696360" n="23">
                             <staff xml:id="staff-0000000623497806" n="1">
@@ -2344,6 +2569,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000016163823" n="24">
                             <staff xml:id="staff-0000000754375717" n="1">
@@ -2374,6 +2609,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001700473557" n="25">
                             <staff xml:id="staff-0000000446371761" n="1">
@@ -2404,6 +2644,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000665625197" n="26">
                             <staff xml:id="staff-0000001472329863" n="1">
@@ -2467,6 +2712,21 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000446436528" n="28">
                             <staff xml:id="staff-0000001126986659" n="1">
@@ -2492,6 +2752,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000094332557" n="29">
                             <staff xml:id="staff-0000000974257480" n="1">
@@ -2520,6 +2785,26 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001711379764" n="30">
                             <staff xml:id="staff-0000000536493021" n="1">
@@ -2544,6 +2829,26 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000808012465" n="31">
                             <staff xml:id="staff-0000001403656205" n="1">
@@ -2566,6 +2871,39 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <supplied resp="#rettinghaus">
+                                <harm place="above" staff="1" tstamp="1">
+                                    <fb>
+                                        <f>7</f>
+                                    </fb>
+                                </harm>
+                                <harm place="above" staff="1" tstamp="2">
+                                    <fb>
+                                        <f>7</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
+                            <choice>
+                                <corr resp="#rettinghaus">
+                                    <harm place="above" staff="1" tstamp="3">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </corr>
+                                <sic>
+                                    <harm place="above" staff="1" tstamp="3.5">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </sic>
+                            </choice>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001097449125" n="32">
                             <staff xml:id="staff-0000000920741306" n="1">
@@ -2587,6 +2925,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6⃥</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000366245153" n="33">
                             <staff xml:id="staff-0000000606057497" n="1">
@@ -2609,6 +2957,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001025439776" n="34">
                             <staff xml:id="staff-0000001272086118" n="1">
@@ -2622,6 +2980,22 @@
                                     <note xml:id="note-0000001548371982" dur="4" oct="2" pname="b" accid.ges="s" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>5</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>♯</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001698329280" n="35">
                             <staff xml:id="staff-0000000707570821" n="1">
@@ -2638,6 +3012,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000407784154" n="36">
                             <staff xml:id="staff-0000001198365918" n="1">
@@ -2666,6 +3050,27 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <choice>
+                                <corr resp="#rettinghaus">
+                                    <harm place="above" staff="1" tstamp="4">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </corr>
+                                <sic>
+                                    <harm place="above" staff="1" tstamp="3.75">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </sic>
+                            </choice>
                         </measure>
                         <measure xml:id="measure-0000001190627964" n="37">
                             <staff xml:id="staff-0000002068558781" n="1">
@@ -2682,6 +3087,19 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                    <f>2</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000409265327" n="38">
                             <staff xml:id="staff-0000001398219271" n="1">
@@ -2710,6 +3128,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001938791443" n="39">
                             <staff xml:id="staff-0000000982976717" n="1">
@@ -2746,11 +3174,11 @@
                                         <note xml:id="note-0000001548530569" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
                                         <note xml:id="note-0000000053717964" dur="16" oct="3" pname="g" accid.ges="s" />
                                     </beam>
-                                    <clef xml:id="clef-0000001695362886" shape="C" line="4" />
                                     <beam>
                                         <note xml:id="note-0000001605504993" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
                                         <note xml:id="note-0000001846566269" dur="16" oct="4" pname="e" accid.ges="s" />
                                     </beam>
+                                    <clef xml:id="clef-0000001695362886" shape="C" line="4" />
                                     <beam>
                                         <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000000744873548" dur="8" oct="4" pname="e" accid.ges="s" />
@@ -2767,6 +3195,11 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001024740628" n="41">
                             <staff xml:id="staff-0000000039306765" n="1">
@@ -2789,11 +3222,20 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000090150956" n="42">
                             <staff xml:id="staff-0000000254065927" n="1">
                                 <layer n="1">
-                                    <clef xml:id="clef-0000001498375363" shape="F" line="4" />
                                     <beam>
                                         <note xml:id="note-0000000069278807" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
                                         <note xml:id="note-0000001611834371" dur="16" oct="3" pname="f" accid.ges="s" />
@@ -2802,15 +3244,12 @@
                                         <note xml:id="note-0000001801830825" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
                                         <note xml:id="note-0000000764209808" dur="16" oct="4" pname="d" accid.ges="s" />
                                     </beam>
+                                    <clef xml:id="clef-0000001498375363" shape="F" line="4" />
                                     <beam>
                                         <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001573959307" dur="8" oct="3" pname="e" accid.ges="s" />
                                             <note xml:id="note-0000000338646465" dur="8" oct="3" pname="f" accid.ges="s" />
                                             <note xml:id="note-0000000467148891" dur="8" oct="3" pname="g" accid.ges="s" />
-                                        </tuplet>
-                                    </beam>
-                                    <beam>
-                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
                                             <note xml:id="note-0000001324864289" dur="8" oct="3" pname="a" accid.ges="s" />
                                             <note xml:id="note-0000001243550684" dur="8" oct="3" pname="b" accid.ges="s" />
                                             <note xml:id="note-0000001445800829" dur="8" oct="4" pname="c" accid.ges="s" />
@@ -2818,6 +3257,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001337206176" n="43">
                             <staff xml:id="staff-0000000780538774" n="1">
@@ -2853,6 +3302,21 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>7</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000595461325" n="45">
                             <staff xml:id="staff-0000001544499059" n="1">
@@ -2868,14 +3332,19 @@
                                             <note xml:id="note-0000000491883760" dur="8" oct="4" pname="c" accid.ges="s" />
                                         </tuplet>
                                     </beam>
-                                    <note xml:id="note-0000000130401844" dur="4" oct="3" pname="b" accid.ges="s" />
                                     <clef xml:id="clef-0000000144881338" shape="C" line="4" />
+                                    <note xml:id="note-0000000130401844" dur="4" oct="3" pname="b" accid.ges="s" />
                                     <beam>
                                         <note xml:id="note-0000000638050957" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
                                         <note xml:id="note-0000000500660317" dur="16" oct="3" pname="e" accid.ges="s" />
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001589269306" n="46">
                             <staff xml:id="staff-0000002128681460" n="1">
@@ -2898,6 +3367,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001418854709" n="47">
                             <staff xml:id="staff-0000001300880243" n="1">
@@ -2917,6 +3396,24 @@
                                     <note xml:id="note-0000001095742329" dur="4" oct="3" pname="g" accid.ges="s" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                    <f>2</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="3">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000434807678" n="48">
                             <staff xml:id="staff-0000000899922947" n="1">
@@ -2965,6 +3462,16 @@
                                     </beam>
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="4">
+                                <fb>
+                                    <f>6</f>
+                                </fb>
+                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001975975990" right="rptend" n="50">
                             <staff xml:id="staff-0000000354552036" n="1">
@@ -2975,6 +3482,18 @@
                                     <rest xml:id="rest-0000002090582923" dur="4" />
                                 </layer>
                             </staff>
+                            <harm place="above" staff="1" tstamp="1">
+                                <fb>
+                                    <f>6</f>
+                                    <f>4</f>
+                                </fb>
+                            </harm>
+                            <harm place="above" staff="1" tstamp="2">
+                                <fb>
+                                    <f />
+                                    <f>3</f>
+                                </fb>
+                            </harm>
                         </measure>
                     </section>
                 </score>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="4.0.0">
     <meiHead>
@@ -62,9 +62,12 @@
     </meiHead>
     <music>
         <body>
-            <mdiv>
+            <mdiv n="1">
                 <score>
                     <scoreDef key.pname="d" key.accid="f" key.mode="major">
+                        <pgHead>
+                            <rend halign="center" fontsize="large">Der Ober-Classe vier und zwantzigſtes und letztes Prob-Stück.</rend>
+                        </pgHead>
                         <staffGrp>
                             <staffDef n="1" lines="5" clef.shape="F" clef.line="4">
                                 <keySig mode="major" sig="4f" />
@@ -102,19 +105,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb></fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>6</f>
@@ -165,16 +155,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002035340213" n="3">
                             <staff xml:id="staff-0000000379032343" n="1">
@@ -205,11 +185,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -252,11 +227,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000102124254" n="5">
                             <staff xml:id="staff-0000000725181426" n="1">
@@ -269,17 +239,6 @@
                                     <note xml:id="note-0000000397966656" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                    <f>5</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -318,11 +277,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000891114586" n="7">
                             <staff xml:id="staff-0000001252141370" n="1">
@@ -345,26 +299,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
@@ -417,16 +351,6 @@
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>♮</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000162621610" n="9">
                             <staff xml:id="staff-0000000204745892" n="1">
@@ -445,16 +369,6 @@
                                     <rest xml:id="rest-0000001100153303" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -507,21 +421,6 @@
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>♭</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>♮</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001710838335" n="11">
                             <staff xml:id="staff-0000002096950072" n="1">
@@ -538,11 +437,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
@@ -573,11 +467,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
@@ -621,16 +510,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001263701703" n="14">
                             <staff xml:id="staff-0000000156889322" n="1">
@@ -659,11 +538,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
@@ -702,11 +576,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001858057008" n="16">
                             <staff xml:id="staff-0000001135171590" n="1">
@@ -734,11 +603,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000142862741" n="17">
                             <staff xml:id="staff-0000000437249946" n="1">
@@ -752,12 +616,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                    <f>5</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -801,21 +659,6 @@
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001832926414" n="19">
                             <staff xml:id="staff-0000000739927200" n="1">
@@ -838,26 +681,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -918,21 +741,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001406646077" right="rptend" n="21">
                             <staff xml:id="staff-0000002053450868" n="1">
@@ -943,17 +751,6 @@
                                     <rest xml:id="rest-0000001740142267" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                    <f>4</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>3</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -998,11 +795,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001265165097" n="23">
                             <staff xml:id="staff-0000000449046634" n="1">
@@ -1032,16 +824,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>♮</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -1085,11 +867,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002003382240" n="25">
                             <staff xml:id="staff-0000001784982246" n="1">
@@ -1118,11 +895,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -1200,17 +972,6 @@
                                     <f>4</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>♮</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6⃥</f>
-                                    <f>4</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000435002289" n="28">
                             <staff xml:id="staff-0000001436313935" n="1">
@@ -1241,11 +1002,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000199158692" n="29">
                             <staff xml:id="staff-0000002080068433" n="1">
@@ -1270,26 +1026,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
@@ -1352,26 +1088,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>7♮</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000875647534" n="31">
                             <staff xml:id="staff-0000001560284680" n="1">
@@ -1394,26 +1110,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>7</f>
@@ -1461,16 +1157,6 @@
                                     <f>6⃥</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6⃥</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000744730060" n="33">
                             <staff xml:id="staff-0000000564951177" n="1">
@@ -1493,16 +1179,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>♮</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="2">
                                 <fb>
                                     <f>♮</f>
@@ -1542,22 +1218,6 @@
                                     <f>♮</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                    <f>5</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>♮</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001066470152" n="35">
                             <staff xml:id="staff-0000001168727038" n="1">
@@ -1576,11 +1236,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>6</f>
@@ -1624,16 +1279,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000950606191" n="37">
                             <staff xml:id="staff-0000001111322519" n="1">
@@ -1652,13 +1297,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                    <f>4</f>
-                                    <f>2</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="4">
                                 <fb>
                                     <f>6</f>
@@ -1704,26 +1342,22 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="3.75">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3.75">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
+                            <choice>
+                              <corr>
+                                  <harm place="above" staff="1" tstamp="4">
+                                      <fb>
+                                          <f>6</f>
+                                      </fb>
+                                  </harm>
+                              </corr>
+                                <sic>
+                                    <harm place="above" staff="1" tstamp="3.75">
+                                        <fb>
+                                            <f>6</f>
+                                        </fb>
+                                    </harm>
+                                </sic>
+                            </choice>
                         </measure>
                         <measure xml:id="measure-0000000669748467" n="39">
                             <staff xml:id="staff-0000000752653766" n="1">
@@ -1788,11 +1422,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000493479060" n="41">
                             <staff xml:id="staff-0000000700945596" n="1">
@@ -1817,16 +1446,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="3">
                                 <fb>
                                     <f>7</f>
@@ -1885,21 +1504,6 @@
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2.75">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001397417464" n="43">
                             <staff xml:id="staff-0000001825286296" n="1">
@@ -1914,7 +1518,8 @@
                                 </layer>
                             </staff>
                             <harm place="above" staff="1" tstamp="2">
-                                <fb></fb>
+                                <fb>
+                                </fb>
                             </harm>
                         </measure>
                         <measure xml:id="measure-0000001968799557" n="44">
@@ -1953,21 +1558,6 @@
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002107539468" n="45">
                             <staff xml:id="staff-0000001735475179" n="1">
@@ -1991,26 +1581,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -2077,26 +1647,6 @@
                                     <f>7</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="3">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>7</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000000601026268" n="47">
                             <staff xml:id="staff-0000000709502839" n="1">
@@ -2119,16 +1669,6 @@
                                     <clef xml:id="clef-0000000352065921" shape="F" line="4" />
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                             <harm place="above" staff="1" tstamp="1">
                                 <fb>
                                     <f>6</f>
@@ -2171,11 +1711,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002102094302" n="49">
                             <staff xml:id="staff-0000002086649027" n="1">
@@ -2212,16 +1747,6 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="4">
-                                <fb>
-                                    <f>6</f>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000002144905428" right="rptend" n="50">
                             <staff xml:id="staff-0000001001903461" n="1">
@@ -2243,1211 +1768,1199 @@
                                     <f>3</f>
                                 </fb>
                             </harm>
-                            <harm place="above" staff="1" tstamp="1">
-                                <fb>
-                                    <f>6</f>
-                                    <f>4</f>
-                                </fb>
-                            </harm>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                    <f>3</f>
-                                </fb>
-                            </harm>
                         </measure>
                     </section>
                 </score>
             </mdiv>
-            <mdiv>
+            <mdiv n="2">
                 <score>
+                    <scoreDef key.pname="c" key.accid="s" key.mode="major">
+                        <pgHead>
+                            <rend halign="center" fontsize="large">Daſſelbige Prob-Stück, anders notirt.</rend>
+                        </pgHead>
+                        <staffGrp>
+                            <staffDef n="1" lines="5" clef.shape="F" clef.line="4">
+                                <keySig mode="major" sig="7s" />
+                                <meterSig count="4" unit="4" sym="common" />
+                            </staffDef>
+                        </staffGrp>
+                    </scoreDef>
                     <section>
-                        <scoreDef key.pname="c" key.accid="s" key.mode="major">
-                            <staffGrp>
-                                <staffDef n="1" lines="5" clef.shape="F" clef.line="4">
-                                    <keySig mode="major" sig="7s" />
-                                    <meterSig count="4" unit="4" sym="common" />
-                                </staffDef>
-                            </staffGrp>
-                        </scoreDef>
-                        <section>
-                            <measure xml:id="measure-0000000764616467" n="1">
-                                <staff xml:id="staff-0000000744224883" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000884058691" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001605100784" dur="16" oct="3" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001724281296" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000355160424" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001631327144" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000001856661415" dur="8" oct="3" pname="f" accid.ges="s" />
-                                                <note xml:id="note-0000001358046671" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001845332529" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000067821288" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001326070991" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                                <dir place="above" staff="1" tstamp="1">
-                                    <rend>Daſſelbige Prob-Stück, anders notiert.</rend>
-                                </dir>
-                            </measure>
-                            <measure xml:id="measure-0000001175975872" n="2">
-                                <staff xml:id="staff-0000000773605129" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000490626990" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001820393954" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000545138312" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001144025339" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001010761674" dur="8" oct="3" pname="f" accid.ges="s" />
-                                                <note xml:id="note-0000000734812381" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000000815906461" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001581281604" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000921962667" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001178026361" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000502201132" n="3">
-                                <staff xml:id="staff-0000002082697360" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001812266927" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000292740818" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001768435736" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000000070780368" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000762380103" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000000726035574" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000384789609" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000588607502" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000000444443513" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000354030605" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001401738767" n="4">
-                                <staff xml:id="staff-0000000332747288" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000614143454" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000002107281195" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000223837613" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001543961466" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001423033669" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000002007610777" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001571422491" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000380888921" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000273665314" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000411291759" dur="8" oct="4" pname="f" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001587219727" n="5">
-                                <staff xml:id="staff-0000001045443423" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000827092506" dur="4" oct="3" pname="b" accid.ges="s" />
-                                        <note xml:id="note-0000001131837576" dur="4" oct="4" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000899501536" dur="4" oct="3" pname="f" accid.ges="s" />
-                                        <note xml:id="note-0000000973228543" dur="4" oct="3" pname="g" accid.ges="s" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000475728550" n="6">
-                                <staff xml:id="staff-0000001642700673" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000200721037" dur="4" oct="3" pname="c" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000000727470370" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000002062092263" dur="16" oct="3" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001764585190" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000642567921" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000797685594" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000006773408" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001479825673" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000110952716" n="7">
-                                <staff xml:id="staff-0000000872595296" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000923504111" dur="4" oct="3" pname="a" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000000047263201" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000578108872" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000893797630" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000212633215" dur="16" oct="4" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001899134064" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000000854120899" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000001006319818" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001697363549" n="8">
-                                <staff xml:id="staff-0000002101548864" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001604771821" dur="4" oct="3" pname="b" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001661445224" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001702804355" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001015499325" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000553057017" dur="16" oct="4" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000002047723069" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000122447062" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000716898980" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000757918812" n="9">
-                                <staff xml:id="staff-0000001472180762" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000002042344894" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001077563975" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001066210210" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000638499985" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <note xml:id="note-0000000635275966" dur="4" oct="3" pname="g">
-                                            <accid xml:id="accid-0000000479775676" accid="x" accid.ges="ss" />
-                                        </note>
-                                        <rest xml:id="rest-0000000573191109" dur="4" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000254425924" n="10">
-                                <staff xml:id="staff-0000000524876795" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001377789174" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001797478494" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001945802122" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001815390300" dur="16" oct="3" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000002066288632" dur="8" oct="3" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000981589083" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000002035426915" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001972618108" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000536199073" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000855700431" n="11">
-                                <staff xml:id="staff-0000000431803279" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000459778729" dur="4" oct="2" pname="a" accid.ges="s" />
-                                        <rest xml:id="rest-0000001444228566" dur="4" />
-                                        <beam>
-                                            <note xml:id="note-0000001395905329" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001464963029" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000002050276005" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000639114449" dur="16" oct="2" pname="b" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000480765356" n="12">
-                                <staff xml:id="staff-0000000721436292" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001343549689" dur="8" oct="3" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000000354499783" dur="8" oct="3" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000001838667451" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001718483658" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001432289757" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001256191597" dots="1" dur="8" oct="2" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000582755696" dur="16" oct="2" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001533676369" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000625672781" dur="16" oct="2" pname="a" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001902389584" n="13">
-                                <staff xml:id="staff-0000001713842588" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001413049993" dur="8" oct="2" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001850938123" dur="8" oct="3" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000002125083453" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000742928234" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000955178658" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000001451639501" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000000933988245" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001076723643" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000111508441" dur="16" oct="2" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000947493869" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001533022994" dur="16" oct="2" pname="b" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001970287854" n="14">
-                                <staff xml:id="staff-0000000389379752" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001579077386" dur="8" oct="3" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001694252719" dur="8" oct="3" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000161005213" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000493714939" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000001572945288" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000000985250173" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000000435833378" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000655330666" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000083369891" dur="16" oct="2" pname="b" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001516012600" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000074266241" dur="16" oct="3" pname="c" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000737409305" n="15">
-                                <staff xml:id="staff-0000001663114451" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000987571877" dur="8" oct="3" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000586950636" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000001196347627" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000000713796245" accid="x" accid.ges="ss" />
-                                                </note>
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000120342237" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000001930281186" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000054685564" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000002115104359" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000464744899" dur="16" oct="3" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001186779428" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000046290007" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000002052761829" n="16">
-                                <staff xml:id="staff-0000000251515494" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001866586254" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000339408917" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000000801872723" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000000465945434" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000366288453" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000979237543" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000951554070" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000001381501838" dur="4" oct="3" pname="f" />
-                                        <note xml:id="note-0000000862439997" dur="4" oct="3" pname="g" accid.ges="s" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000909772819" n="17">
-                                <staff xml:id="staff-0000001749432153" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001892176289" dur="4" oct="3" pname="c" accid.ges="s" />
-                                        <note xml:id="note-0000000296743897" dur="4" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000314073485" dur="4" oct="2" pname="g" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000000003226096" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000321875728" dur="16" oct="2" pname="g" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000282283820" n="18">
-                                <staff xml:id="staff-0000000468308935" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000190922055" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000459531614" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000546264686" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000000091114487" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000000883388234" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000002032901722" dur="8" oct="3" pname="f" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000000565163580" dur="4" oct="3" pname="e" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001553076753" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001617199884" dur="16" oct="2" pname="a" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000381047696" n="19">
-                                <staff xml:id="staff-0000000594999269" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001177065973" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001132602233" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000286928020" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000001117840192" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000259583450" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000001268307424" dur="4" oct="3" pname="f">
-                                            <accid xml:id="accid-0000001834538927" accid="x" accid.ges="ss" />
-                                        </note>
-                                        <beam>
-                                            <note xml:id="note-0000000775109616" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001688098786" dur="16" oct="2" pname="b" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000325841885" n="20">
-                                <staff xml:id="staff-0000001986942719" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001810516893" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001766510755" dur="16" oct="3" pname="b" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000304809956" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000001316941531" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000793867271" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000680492399" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000924022597" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000401002294" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000000533186712" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000914137515" n="21">
-                                <staff xml:id="staff-0000000948774911" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000158139362" dur="4" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001308814645" dur="4" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000000100158580" dur="4" oct="3" pname="g" accid.ges="s" />
-                                        <rest xml:id="rest-0000001885827303" dur="4" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001848293689" n="22">
-                                <staff xml:id="staff-0000001942633863" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000062167710" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000245569379" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000002029909291" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001500533507" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000428512572" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001046025130" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000002073817613" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001098755599" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000001212357256" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000000929058141" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000000035242341" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001820696360" n="23">
-                                <staff xml:id="staff-0000000623497806" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001940637350" dur="4" oct="3" pname="d">
-                                            <accid xml:id="accid-0000002049854058" accid="x" accid.ges="ss" />
-                                        </note>
-                                        <beam>
-                                            <note xml:id="note-0000000718432221" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001468599576" dur="16" oct="3" pname="b" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000718030830" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000168420618" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000527410320" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001354247949" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000001458763312" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000000732527058" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000001624645529" dur="8" oct="3" pname="d">
-                                                    <accid xml:id="accid-0000000382031787" accid="x" accid.ges="ss" />
-                                                </note>
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000016163823" n="24">
-                                <staff xml:id="staff-0000000754375717" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001320844286" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000002108957504" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000002023944786" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000141229366" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000791791481" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001755937519" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001484855441" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001935429539" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000001903316517" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000000247298444" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000001146828094" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001700473557" n="25">
-                                <staff xml:id="staff-0000000446371761" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000807377370" dots="1" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000001966929740" accid="x" accid.ges="ss" />
+                        <measure xml:id="measure-0000000764616467" n="1">
+                            <staff xml:id="staff-0000000744224883" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000884058691" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000001605100784" dur="16" oct="3" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001724281296" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000355160424" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001631327144" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001856661415" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000001358046671" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001845332529" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000067821288" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001326070991" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001175975872" n="2">
+                            <staff xml:id="staff-0000000773605129" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000490626990" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001820393954" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000545138312" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001144025339" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001010761674" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000000734812381" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000815906461" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001581281604" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000921962667" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001178026361" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000502201132" n="3">
+                            <staff xml:id="staff-0000002082697360" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001812266927" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000292740818" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001768435736" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000000070780368" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000762380103" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000726035574" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000384789609" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000588607502" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000444443513" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000354030605" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001401738767" n="4">
+                            <staff xml:id="staff-0000000332747288" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000614143454" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000002107281195" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000223837613" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000001543961466" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001423033669" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000002007610777" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001571422491" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000380888921" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000273665314" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000411291759" dur="8" oct="4" pname="f" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001587219727" n="5">
+                            <staff xml:id="staff-0000001045443423" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000827092506" dur="4" oct="3" pname="b" accid.ges="s" />
+                                    <note xml:id="note-0000001131837576" dur="4" oct="4" pname="c" accid.ges="s" />
+                                    <note xml:id="note-0000000899501536" dur="4" oct="3" pname="f" accid.ges="s" />
+                                    <note xml:id="note-0000000973228543" dur="4" oct="3" pname="g" accid.ges="s" />
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000475728550" n="6">
+                            <staff xml:id="staff-0000001642700673" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000200721037" dur="4" oct="3" pname="c" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000000727470370" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000002062092263" dur="16" oct="3" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001764585190" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000642567921" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000797685594" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000006773408" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001479825673" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000110952716" n="7">
+                            <staff xml:id="staff-0000000872595296" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000923504111" dur="4" oct="3" pname="a" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000000047263201" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000578108872" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000893797630" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000212633215" dur="16" oct="4" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001899134064" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000854120899" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001006319818" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001697363549" n="8">
+                            <staff xml:id="staff-0000002101548864" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001604771821" dur="4" oct="3" pname="b" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001661445224" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001702804355" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001015499325" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000553057017" dur="16" oct="4" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000002047723069" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000122447062" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000716898980" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000757918812" n="9">
+                            <staff xml:id="staff-0000001472180762" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000002042344894" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000001077563975" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001066210210" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000000638499985" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <note xml:id="note-0000000635275966" dur="4" oct="3" pname="g">
+                                        <accid xml:id="accid-0000000479775676" accid="x" accid.ges="ss" />
+                                    </note>
+                                    <rest xml:id="rest-0000000573191109" dur="4" />
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000254425924" n="10">
+                            <staff xml:id="staff-0000000524876795" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001377789174" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001797478494" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001945802122" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001815390300" dur="16" oct="3" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000002066288632" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000981589083" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000002035426915" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001972618108" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000536199073" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000855700431" n="11">
+                            <staff xml:id="staff-0000000431803279" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000459778729" dur="4" oct="2" pname="a" accid.ges="s" />
+                                    <rest xml:id="rest-0000001444228566" dur="4" />
+                                    <beam>
+                                        <note xml:id="note-0000001395905329" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001464963029" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000002050276005" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000639114449" dur="16" oct="2" pname="b" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000480765356" n="12">
+                            <staff xml:id="staff-0000000721436292" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001343549689" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000354499783" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001838667451" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001718483658" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001432289757" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001256191597" dots="1" dur="8" oct="2" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000582755696" dur="16" oct="2" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001533676369" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000000625672781" dur="16" oct="2" pname="a" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001902389584" n="13">
+                            <staff xml:id="staff-0000001713842588" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001413049993" dur="8" oct="2" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001850938123" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000002125083453" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000742928234" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000955178658" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000001451639501" accid="x" accid.ges="ss" />
                                             </note>
-                                            <note xml:id="note-0000001322189417" dur="16" oct="3" pname="f" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000772400596" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000347027401" dur="16" oct="4" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000578604769" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000001094782682" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001215084779" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001054617140" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000811275271" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000002069133086" dur="8" oct="3" pname="f" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000665625197" n="26">
-                                <staff xml:id="staff-0000001472329863" n="1">
-                                    <layer n="1">
-                                        <clef xml:id="clef-0000000606241355" shape="C" line="4" />
-                                        <beam>
-                                            <note xml:id="note-0000000839981317" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000639573712" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001034560173" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001718280590" dur="16" oct="4" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000692716894" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000772923558" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000001682644555" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000722533715" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000224176227" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000001169793254" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000216118412" n="27">
-                                <staff xml:id="staff-0000001555329041" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001930689065" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001701135200" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001347753363" dots="1" dur="8" oct="4" pname="f">
-                                                <accid xml:id="accid-0000000172627577" accid="x" accid.ges="ss" />
+                                            <note xml:id="note-0000000933988245" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001076723643" dots="1" dur="8" oct="2" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000000111508441" dur="16" oct="2" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000947493869" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001533022994" dur="16" oct="2" pname="b" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001970287854" n="14">
+                            <staff xml:id="staff-0000000389379752" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001579077386" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001694252719" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000161005213" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000493714939" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000001572945288" accid="x" accid.ges="ss" />
                                             </note>
-                                            <note xml:id="note-0000001080325538" dur="16" oct="4" pname="f" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000124385170" dur="8" oct="4" pname="f" />
-                                                <note xml:id="note-0000001848050969" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000963473174" dur="8" oct="4" pname="d">
-                                                    <accid xml:id="accid-0000001987635463" accid="x" accid.ges="ss" />
-                                                </note>
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001546081425" dur="8" oct="4" pname="d" />
-                                                <note xml:id="note-0000000113432273" dur="8" oct="4" pname="c">
-                                                    <accid xml:id="accid-0000001785693073" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000001977064248" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000446436528" n="28">
-                                <staff xml:id="staff-0000001126986659" n="1">
-                                    <layer n="1">
-                                        <clef xml:id="clef-0000001321939318" shape="F" line="4" />
-                                        <rest xml:id="rest-0000001348294977" dur="4" />
-                                        <beam>
-                                            <note xml:id="note-0000000361225615" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001293769440" dur="16" oct="2" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001383830308" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001929750270" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000586067903" dur="8" oct="3" pname="d">
-                                                    <accid xml:id="accid-0000000528836041" accid="s" accid.ges="s" />
-                                                </note>
-                                                <note xml:id="note-0000000107328038" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000001055484596" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000094332557" n="29">
-                                <staff xml:id="staff-0000000974257480" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001531125584" dur="4" oct="3" pname="c">
-                                            <accid xml:id="accid-0000000059963860" accid="x" accid.ges="ss" />
+                                            <note xml:id="note-0000000985250173" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000435833378" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000655330666" dots="1" dur="8" oct="2" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000000083369891" dur="16" oct="2" pname="b" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001516012600" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000074266241" dur="16" oct="3" pname="c" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000737409305" n="15">
+                            <staff xml:id="staff-0000001663114451" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000987571877" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000586950636" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001196347627" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000000713796245" accid="x" accid.ges="ss" />
+                                            </note>
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000120342237" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001930281186" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000054685564" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000002115104359" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000464744899" dur="16" oct="3" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001186779428" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000046290007" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000002052761829" n="16">
+                            <staff xml:id="staff-0000000251515494" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001866586254" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000339408917" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000000801872723" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000000465945434" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000366288453" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000979237543" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000951554070" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000001381501838" dur="4" oct="3" pname="f" />
+                                    <note xml:id="note-0000000862439997" dur="4" oct="3" pname="g" accid.ges="s" />
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000909772819" n="17">
+                            <staff xml:id="staff-0000001749432153" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001892176289" dur="4" oct="3" pname="c" accid.ges="s" />
+                                    <note xml:id="note-0000000296743897" dur="4" oct="3" pname="d" accid.ges="s" />
+                                    <note xml:id="note-0000000314073485" dur="4" oct="2" pname="g" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000000003226096" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000321875728" dur="16" oct="2" pname="g" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000282283820" n="18">
+                            <staff xml:id="staff-0000000468308935" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000190922055" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000459531614" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000546264686" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000000091114487" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000000883388234" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000002032901722" dur="8" oct="3" pname="f" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000000565163580" dur="4" oct="3" pname="e" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001553076753" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001617199884" dur="16" oct="2" pname="a" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000381047696" n="19">
+                            <staff xml:id="staff-0000000594999269" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001177065973" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001132602233" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000286928020" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001117840192" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000259583450" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000001268307424" dur="4" oct="3" pname="f">
+                                        <accid xml:id="accid-0000001834538927" accid="x" accid.ges="ss" />
+                                    </note>
+                                    <beam>
+                                        <note xml:id="note-0000000775109616" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001688098786" dur="16" oct="2" pname="b" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000325841885" n="20">
+                            <staff xml:id="staff-0000001986942719" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001810516893" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001766510755" dur="16" oct="3" pname="b" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000304809956" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001316941531" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000793867271" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000680492399" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000924022597" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000401002294" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000000533186712" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000914137515" n="21">
+                            <staff xml:id="staff-0000000948774911" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000158139362" dur="4" oct="4" pname="d" accid.ges="s" />
+                                    <note xml:id="note-0000001308814645" dur="4" oct="3" pname="d" accid.ges="s" />
+                                    <note xml:id="note-0000000100158580" dur="4" oct="3" pname="g" accid.ges="s" />
+                                    <rest xml:id="rest-0000001885827303" dur="4" />
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001848293689" n="22">
+                            <staff xml:id="staff-0000001942633863" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000062167710" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000245569379" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000002029909291" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000001500533507" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000428512572" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001046025130" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000002073817613" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001098755599" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001212357256" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000000929058141" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000000035242341" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001820696360" n="23">
+                            <staff xml:id="staff-0000000623497806" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001940637350" dur="4" oct="3" pname="d">
+                                        <accid xml:id="accid-0000002049854058" accid="x" accid.ges="ss" />
+                                    </note>
+                                    <beam>
+                                        <note xml:id="note-0000000718432221" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001468599576" dur="16" oct="3" pname="b" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000718030830" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000168420618" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000527410320" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001354247949" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000001458763312" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000000732527058" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001624645529" dur="8" oct="3" pname="d">
+                                                <accid xml:id="accid-0000000382031787" accid="x" accid.ges="ss" />
+                                            </note>
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000016163823" n="24">
+                            <staff xml:id="staff-0000000754375717" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001320844286" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000002108957504" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000002023944786" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000141229366" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000791791481" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001755937519" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001484855441" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001935429539" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001903316517" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000000247298444" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000001146828094" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001700473557" n="25">
+                            <staff xml:id="staff-0000000446371761" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000807377370" dots="1" dur="8" oct="3" pname="f">
+                                            <accid xml:id="accid-0000001966929740" accid="x" accid.ges="ss" />
                                         </note>
-                                        <beam>
-                                            <note xml:id="note-0000001209947930" dots="1" dur="8" oct="3" pname="f">
-                                                <accid xml:id="accid-0000000920227066" accid="x" accid.ges="ss" />
-                                            </note>
-                                            <note xml:id="note-0000001326635735" dur="16" oct="2" pname="f">
-                                                <accid xml:id="accid-0000001918672053" accid="x" accid.ges="ss" />
-                                            </note>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000377147855" dots="1" dur="8" oct="3" pname="f" />
-                                            <note xml:id="note-0000001400224495" dur="16" oct="3" pname="f" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001603915126" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000002055679497" dur="8" oct="3" pname="f" />
-                                                <note xml:id="note-0000001103306706" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001711379764" n="30">
-                                <staff xml:id="staff-0000000536493021" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000260688999" dur="4" oct="3" pname="d" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001042429617" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000439405782" dur="16" oct="2" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000655196646" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000186114407" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000002038348578" dur="8" oct="3" pname="f">
-                                                    <accid xml:id="accid-0000002055151772" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000001558317993" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000001061988077" dur="8" oct="3" pname="f" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000808012465" n="31">
-                                <staff xml:id="staff-0000001403656205" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001101808123" dur="4" oct="3" pname="e" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001315618807" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000766081254" dur="16" oct="2" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000002073427895" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000198633226" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001720223442" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000000402121155" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000000717369997" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001097449125" n="32">
-                                <staff xml:id="staff-0000000920741306" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000000566368460" dur="4" oct="3" pname="f">
-                                            <accid xml:id="accid-0000000466149794" accid="x" accid.ges="ss" />
+                                        <note xml:id="note-0000001322189417" dur="16" oct="3" pname="f" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000772400596" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000347027401" dur="16" oct="4" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000578604769" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001094782682" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001215084779" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001054617140" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000811275271" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000002069133086" dur="8" oct="3" pname="f" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000665625197" n="26">
+                            <staff xml:id="staff-0000001472329863" n="1">
+                                <layer n="1">
+                                    <clef xml:id="clef-0000000606241355" shape="C" line="4" />
+                                    <beam>
+                                        <note xml:id="note-0000000839981317" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000639573712" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001034560173" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001718280590" dur="16" oct="4" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000692716894" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000772923558" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000001682644555" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000722533715" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000224176227" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001169793254" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000216118412" n="27">
+                            <staff xml:id="staff-0000001555329041" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001930689065" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001701135200" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001347753363" dots="1" dur="8" oct="4" pname="f">
+                                            <accid xml:id="accid-0000000172627577" accid="x" accid.ges="ss" />
                                         </note>
-                                        <rest xml:id="rest-0000000155881601" dur="4" />
-                                        <clef xml:id="clef-0000000245135638" shape="C" line="4" />
-                                        <beam>
-                                            <note xml:id="note-0000001913864534" dots="1" dur="8" oct="4" pname="f">
-                                                <accid xml:id="accid-0000001728538115" accid="x" accid.ges="ss" />
+                                        <note xml:id="note-0000001080325538" dur="16" oct="4" pname="f" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000124385170" dur="8" oct="4" pname="f" />
+                                            <note xml:id="note-0000001848050969" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000963473174" dur="8" oct="4" pname="d">
+                                                <accid xml:id="accid-0000001987635463" accid="x" accid.ges="ss" />
                                             </note>
-                                            <note xml:id="note-0000000922072168" dur="16" oct="3" pname="b" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001578745991" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001616316323" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000366245153" n="33">
-                                <staff xml:id="staff-0000000606057497" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000259490996" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000002002928631" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000838724541" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000757872116" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000001486794630" dur="16" oct="3" pname="b" accid.ges="s" />
-                                        </beam>
-                                        <note xml:id="note-0000001526138537" dur="4" oct="3" pname="e" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001416601157" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000002021256189" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001025439776" n="34">
-                                <staff xml:id="staff-0000001272086118" n="1">
-                                    <layer n="1">
-                                        <clef xml:id="clef-0000000495369573" shape="F" line="4" />
-                                        <note xml:id="note-0000001380983122" dur="4" oct="3" pname="d">
-                                            <accid xml:id="accid-0000001601911783" accid="x" accid.ges="ss" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001546081425" dur="8" oct="4" pname="d" />
+                                            <note xml:id="note-0000000113432273" dur="8" oct="4" pname="c">
+                                                <accid xml:id="accid-0000001785693073" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000001977064248" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000446436528" n="28">
+                            <staff xml:id="staff-0000001126986659" n="1">
+                                <layer n="1">
+                                    <clef xml:id="clef-0000001321939318" shape="F" line="4" />
+                                    <rest xml:id="rest-0000001348294977" dur="4" />
+                                    <beam>
+                                        <note xml:id="note-0000000361225615" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001293769440" dur="16" oct="2" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001383830308" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001929750270" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000586067903" dur="8" oct="3" pname="d">
+                                                <accid xml:id="accid-0000000528836041" accid="s" accid.ges="s" />
+                                            </note>
+                                            <note xml:id="note-0000000107328038" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001055484596" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000094332557" n="29">
+                            <staff xml:id="staff-0000000974257480" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001531125584" dur="4" oct="3" pname="c">
+                                        <accid xml:id="accid-0000000059963860" accid="x" accid.ges="ss" />
+                                    </note>
+                                    <beam>
+                                        <note xml:id="note-0000001209947930" dots="1" dur="8" oct="3" pname="f">
+                                            <accid xml:id="accid-0000000920227066" accid="x" accid.ges="ss" />
                                         </note>
-                                        <note xml:id="note-0000001267176725" dur="4" oct="3" pname="e" accid.ges="s" />
-                                        <note xml:id="note-0000000026233512" dur="4" oct="2" pname="a" accid.ges="s" />
-                                        <note xml:id="note-0000001548371982" dur="4" oct="2" pname="b" accid.ges="s" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001698329280" n="35">
-                                <staff xml:id="staff-0000000707570821" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001673846375" dur="4" oct="2" pname="e" accid.ges="s" />
-                                        <rest xml:id="rest-0000000691730473" dur="4" />
-                                        <beam>
-                                            <note xml:id="note-0000000655991420" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000025270262" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001627551052" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001030226750" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000407784154" n="36">
-                                <staff xml:id="staff-0000001198365918" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000286175450" dur="8" oct="3" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001138229582" dur="8" oct="2" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000255588969" dur="8" oct="2" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001547989606" dur="8" oct="2" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000000532008841" dur="8" oct="2" pname="f">
-                                                    <accid xml:id="accid-0000000496633418" accid="x" accid.ges="ss" />
-                                                </note>
-                                                <note xml:id="note-0000002028184132" dur="8" oct="2" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000195581117" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000001451064943" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001309429970" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000922692405" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001190627964" n="37">
-                                <staff xml:id="staff-0000002068558781" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001446244714" dur="4" oct="3" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000002083100293" dur="4" oct="2" pname="g" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001022764850" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000001014365471" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000623937958" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000000009225814" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000409265327" n="38">
-                                <staff xml:id="staff-0000001398219271" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001241256177" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000001996301513" dur="8" oct="3" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000211198258" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000002091755926" dur="8" oct="2" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001711341011" dur="8" oct="2" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000001819920353" dur="8" oct="2" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001055936890" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000333896810" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001088590631" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000789863280" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001938791443" n="39">
-                                <staff xml:id="staff-0000000982976717" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000002025763844" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000001967571622" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001716982414" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001905305510" dur="16" oct="4" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000969164854" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000927242269" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001956144303" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000482708927" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000267064325" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000001511524595" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000479101824" n="40">
-                                <staff xml:id="staff-0000000215083342" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001548530569" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000053717964" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <clef xml:id="clef-0000001695362886" shape="C" line="4" />
-                                        <beam>
-                                            <note xml:id="note-0000001605504993" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000001846566269" dur="16" oct="4" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000744873548" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000077924150" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000228220375" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000802569028" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000001156562344" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000000685089000" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001024740628" n="41">
-                                <staff xml:id="staff-0000000039306765" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000002098251702" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000001198772305" dur="16" oct="3" pname="a" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001769736010" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000000732755769" dur="16" oct="4" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000918972868" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            <note xml:id="note-0000002062069861" dur="16" oct="3" pname="b" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001712854170" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000868272524" dur="16" oct="4" pname="e" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000090150956" n="42">
-                                <staff xml:id="staff-0000000254065927" n="1">
-                                    <layer n="1">
-                                        <clef xml:id="clef-0000001498375363" shape="F" line="4" />
-                                        <beam>
-                                            <note xml:id="note-0000000069278807" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000001611834371" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001801830825" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000764209808" dur="16" oct="4" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001573959307" dur="8" oct="3" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000338646465" dur="8" oct="3" pname="f" accid.ges="s" />
-                                                <note xml:id="note-0000000467148891" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000001324864289" dur="8" oct="3" pname="a" accid.ges="s" />
-                                                <note xml:id="note-0000001243550684" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001445800829" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001337206176" n="43">
-                                <staff xml:id="staff-0000000780538774" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001272325229" dur="4" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000001948255782" dur="4" oct="2" pname="g" accid.ges="s" />
-                                        <rest xml:id="rest-0000000055185116" dur="4" />
-                                        <beam>
-                                            <note xml:id="note-0000000156498351" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000025314840" dur="16" oct="3" pname="c" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001798722409" n="44">
-                                <staff xml:id="staff-0000000741600718" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001751268327" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001919417306" dur="16" oct="4" pname="c" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000692265492" dur="8" oct="3" pname="b" accid.ges="s" />
-                                                <note xml:id="note-0000001269329189" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000002097969950" dur="8" oct="3" pname="b" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000001177796869" dur="4" oct="3" pname="a" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000001004535706" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000001691716907" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000595461325" n="45">
-                                <staff xml:id="staff-0000001544499059" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000514812354" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000292053225" dur="16" oct="4" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000238857026" dur="8" oct="4" pname="c" accid.ges="s" />
-                                                <note xml:id="note-0000000534650888" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000491883760" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000000130401844" dur="4" oct="3" pname="b" accid.ges="s" />
-                                        <clef xml:id="clef-0000000144881338" shape="C" line="4" />
-                                        <beam>
-                                            <note xml:id="note-0000000638050957" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000500660317" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001589269306" n="46">
-                                <staff xml:id="staff-0000002128681460" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000636702072" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000488657468" dur="16" oct="4" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000469756257" dur="8" oct="4" pname="d" accid.ges="s" />
-                                                <note xml:id="note-0000000077367046" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000002004205928" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000001003481019" dur="4" oct="4" pname="c" accid.ges="s" />
-                                        <beam>
-                                            <note xml:id="note-0000000427559261" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000001115317562" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001418854709" n="47">
-                                <staff xml:id="staff-0000001300880243" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000001445702015" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
-                                            <note xml:id="note-0000002019398822" dur="16" oct="4" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000000619381560" dur="8" oct="4" pname="e" accid.ges="s" />
-                                                <note xml:id="note-0000000306508323" dur="8" oct="4" pname="f" accid.ges="s" />
-                                                <note xml:id="note-0000002109156844" dur="8" oct="4" pname="e" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <note xml:id="note-0000001671412810" dur="4" oct="4" pname="d" accid.ges="s" />
-                                        <note xml:id="note-0000001095742329" dur="4" oct="3" pname="g" accid.ges="s" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000434807678" n="48">
-                                <staff xml:id="staff-0000000899922947" n="1">
-                                    <layer n="1">
-                                        <clef xml:id="clef-0000000049326528" shape="F" line="4" />
-                                        <beam>
-                                            <note xml:id="note-0000001044404730" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
-                                            <note xml:id="note-0000000206132670" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001878887937" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000001846251732" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
-                                                <note xml:id="note-0000002121513331" dur="8" oct="3" pname="f" accid.ges="s" />
-                                                <note xml:id="note-0000000385024514" dur="8" oct="3" pname="g" accid.ges="s" />
-                                                <note xml:id="note-0000002108317258" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            </tuplet>
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000018165466" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000163000213" dur="16" oct="3" pname="g" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000000924016691" n="49">
-                                <staff xml:id="staff-0000000722337749" n="1">
-                                    <layer n="1">
-                                        <beam>
-                                            <note xml:id="note-0000000475692573" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
-                                            <note xml:id="note-0000000089131372" dur="16" oct="3" pname="d" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000000436966555" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
-                                            <note xml:id="note-0000000958915602" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000001420598158" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
-                                            <note xml:id="note-0000000860637944" dur="16" oct="3" pname="e" accid.ges="s" />
-                                        </beam>
-                                        <beam>
-                                            <note xml:id="note-0000002007151947" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
-                                            <note xml:id="note-0000000640368958" dur="16" oct="3" pname="f" accid.ges="s" />
-                                        </beam>
-                                    </layer>
-                                </staff>
-                            </measure>
-                            <measure xml:id="measure-0000001975975990" right="rptend" n="50">
-                                <staff xml:id="staff-0000000354552036" n="1">
-                                    <layer n="1">
-                                        <note xml:id="note-0000001790422992" dur="4" oct="3" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000411154624" dur="4" oct="2" pname="g" accid.ges="s" />
-                                        <note xml:id="note-0000000098253069" dur="4" oct="3" pname="c" accid.ges="s" />
-                                        <rest xml:id="rest-0000002090582923" dur="4" />
-                                    </layer>
-                                </staff>
-                            </measure>
-                        </section>
+                                        <note xml:id="note-0000001326635735" dur="16" oct="2" pname="f">
+                                            <accid xml:id="accid-0000001918672053" accid="x" accid.ges="ss" />
+                                        </note>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000377147855" dots="1" dur="8" oct="3" pname="f" />
+                                        <note xml:id="note-0000001400224495" dur="16" oct="3" pname="f" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001603915126" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000002055679497" dur="8" oct="3" pname="f" />
+                                            <note xml:id="note-0000001103306706" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001711379764" n="30">
+                            <staff xml:id="staff-0000000536493021" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000260688999" dur="4" oct="3" pname="d" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001042429617" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000439405782" dur="16" oct="2" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000655196646" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000186114407" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000002038348578" dur="8" oct="3" pname="f">
+                                                <accid xml:id="accid-0000002055151772" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000001558317993" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000001061988077" dur="8" oct="3" pname="f" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000808012465" n="31">
+                            <staff xml:id="staff-0000001403656205" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001101808123" dur="4" oct="3" pname="e" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001315618807" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000000766081254" dur="16" oct="2" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000002073427895" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000000198633226" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001720223442" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000402121155" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000000717369997" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001097449125" n="32">
+                            <staff xml:id="staff-0000000920741306" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000000566368460" dur="4" oct="3" pname="f">
+                                        <accid xml:id="accid-0000000466149794" accid="x" accid.ges="ss" />
+                                    </note>
+                                    <rest xml:id="rest-0000000155881601" dur="4" />
+                                    <clef xml:id="clef-0000000245135638" shape="C" line="4" />
+                                    <beam>
+                                        <note xml:id="note-0000001913864534" dots="1" dur="8" oct="4" pname="f">
+                                            <accid xml:id="accid-0000001728538115" accid="x" accid.ges="ss" />
+                                        </note>
+                                        <note xml:id="note-0000000922072168" dur="16" oct="3" pname="b" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001578745991" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001616316323" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000366245153" n="33">
+                            <staff xml:id="staff-0000000606057497" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000259490996" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000002002928631" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000838724541" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000757872116" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000001486794630" dur="16" oct="3" pname="b" accid.ges="s" />
+                                    </beam>
+                                    <note xml:id="note-0000001526138537" dur="4" oct="3" pname="e" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001416601157" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000002021256189" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001025439776" n="34">
+                            <staff xml:id="staff-0000001272086118" n="1">
+                                <layer n="1">
+                                    <clef xml:id="clef-0000000495369573" shape="F" line="4" />
+                                    <note xml:id="note-0000001380983122" dur="4" oct="3" pname="d">
+                                        <accid xml:id="accid-0000001601911783" accid="x" accid.ges="ss" />
+                                    </note>
+                                    <note xml:id="note-0000001267176725" dur="4" oct="3" pname="e" accid.ges="s" />
+                                    <note xml:id="note-0000000026233512" dur="4" oct="2" pname="a" accid.ges="s" />
+                                    <note xml:id="note-0000001548371982" dur="4" oct="2" pname="b" accid.ges="s" />
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001698329280" n="35">
+                            <staff xml:id="staff-0000000707570821" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001673846375" dur="4" oct="2" pname="e" accid.ges="s" />
+                                    <rest xml:id="rest-0000000691730473" dur="4" />
+                                    <beam>
+                                        <note xml:id="note-0000000655991420" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000025270262" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001627551052" dots="1" dur="8" oct="3" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001030226750" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000407784154" n="36">
+                            <staff xml:id="staff-0000001198365918" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000286175450" dur="8" oct="3" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001138229582" dur="8" oct="2" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000255588969" dur="8" oct="2" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001547989606" dur="8" oct="2" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000000532008841" dur="8" oct="2" pname="f">
+                                                <accid xml:id="accid-0000000496633418" accid="x" accid.ges="ss" />
+                                            </note>
+                                            <note xml:id="note-0000002028184132" dur="8" oct="2" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000195581117" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000001451064943" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001309429970" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000922692405" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001190627964" n="37">
+                            <staff xml:id="staff-0000002068558781" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001446244714" dur="4" oct="3" pname="d" accid.ges="s" />
+                                    <note xml:id="note-0000002083100293" dur="4" oct="2" pname="g" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001022764850" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000001014365471" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000623937958" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000000009225814" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000409265327" n="38">
+                            <staff xml:id="staff-0000001398219271" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001241256177" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000001996301513" dur="8" oct="3" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000211198258" dur="8" oct="3" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000002091755926" dur="8" oct="2" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001711341011" dur="8" oct="2" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001819920353" dur="8" oct="2" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001055936890" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000000333896810" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001088590631" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000789863280" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001938791443" n="39">
+                            <staff xml:id="staff-0000000982976717" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000002025763844" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000001967571622" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001716982414" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001905305510" dur="16" oct="4" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000969164854" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000927242269" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001956144303" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000482708927" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000267064325" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001511524595" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000479101824" n="40">
+                            <staff xml:id="staff-0000000215083342" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001548530569" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000053717964" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <clef xml:id="clef-0000001695362886" shape="C" line="4" />
+                                    <beam>
+                                        <note xml:id="note-0000001605504993" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000001846566269" dur="16" oct="4" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000744873548" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000077924150" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000228220375" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000802569028" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000001156562344" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000000685089000" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001024740628" n="41">
+                            <staff xml:id="staff-0000000039306765" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000002098251702" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000001198772305" dur="16" oct="3" pname="a" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001769736010" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000000732755769" dur="16" oct="4" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000918972868" dots="1" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        <note xml:id="note-0000002062069861" dur="16" oct="3" pname="b" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001712854170" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000868272524" dur="16" oct="4" pname="e" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000090150956" n="42">
+                            <staff xml:id="staff-0000000254065927" n="1">
+                                <layer n="1">
+                                    <clef xml:id="clef-0000001498375363" shape="F" line="4" />
+                                    <beam>
+                                        <note xml:id="note-0000000069278807" dots="1" dur="8" oct="3" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000001611834371" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001801830825" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000764209808" dur="16" oct="4" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001573959307" dur="8" oct="3" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000338646465" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000000467148891" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000001324864289" dur="8" oct="3" pname="a" accid.ges="s" />
+                                            <note xml:id="note-0000001243550684" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001445800829" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001337206176" n="43">
+                            <staff xml:id="staff-0000000780538774" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001272325229" dur="4" oct="3" pname="g" accid.ges="s" />
+                                    <note xml:id="note-0000001948255782" dur="4" oct="2" pname="g" accid.ges="s" />
+                                    <rest xml:id="rest-0000000055185116" dur="4" />
+                                    <beam>
+                                        <note xml:id="note-0000000156498351" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000025314840" dur="16" oct="3" pname="c" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001798722409" n="44">
+                            <staff xml:id="staff-0000000741600718" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001751268327" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000001919417306" dur="16" oct="4" pname="c" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000692265492" dur="8" oct="3" pname="b" accid.ges="s" />
+                                            <note xml:id="note-0000001269329189" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000002097969950" dur="8" oct="3" pname="b" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000001177796869" dur="4" oct="3" pname="a" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000001004535706" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000001691716907" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000595461325" n="45">
+                            <staff xml:id="staff-0000001544499059" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000514812354" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000292053225" dur="16" oct="4" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000238857026" dur="8" oct="4" pname="c" accid.ges="s" />
+                                            <note xml:id="note-0000000534650888" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000491883760" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000000130401844" dur="4" oct="3" pname="b" accid.ges="s" />
+                                    <clef xml:id="clef-0000000144881338" shape="C" line="4" />
+                                    <beam>
+                                        <note xml:id="note-0000000638050957" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000500660317" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001589269306" n="46">
+                            <staff xml:id="staff-0000002128681460" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000636702072" dots="1" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000488657468" dur="16" oct="4" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000469756257" dur="8" oct="4" pname="d" accid.ges="s" />
+                                            <note xml:id="note-0000000077367046" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000002004205928" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000001003481019" dur="4" oct="4" pname="c" accid.ges="s" />
+                                    <beam>
+                                        <note xml:id="note-0000000427559261" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000001115317562" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001418854709" n="47">
+                            <staff xml:id="staff-0000001300880243" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000001445702015" dots="1" dur="8" oct="4" pname="f" accid.ges="s" />
+                                        <note xml:id="note-0000002019398822" dur="16" oct="4" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000000619381560" dur="8" oct="4" pname="e" accid.ges="s" />
+                                            <note xml:id="note-0000000306508323" dur="8" oct="4" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000002109156844" dur="8" oct="4" pname="e" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <note xml:id="note-0000001671412810" dur="4" oct="4" pname="d" accid.ges="s" />
+                                    <note xml:id="note-0000001095742329" dur="4" oct="3" pname="g" accid.ges="s" />
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000434807678" n="48">
+                            <staff xml:id="staff-0000000899922947" n="1">
+                                <layer n="1">
+                                    <clef xml:id="clef-0000000049326528" shape="F" line="4" />
+                                    <beam>
+                                        <note xml:id="note-0000001044404730" dots="1" dur="8" oct="4" pname="d" accid.ges="s" />
+                                        <note xml:id="note-0000000206132670" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001878887937" dots="1" dur="8" oct="4" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000001846251732" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <tuplet num="3" numbase="2" num.visible="false" bracket.visible="false">
+                                            <note xml:id="note-0000002121513331" dur="8" oct="3" pname="f" accid.ges="s" />
+                                            <note xml:id="note-0000000385024514" dur="8" oct="3" pname="g" accid.ges="s" />
+                                            <note xml:id="note-0000002108317258" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        </tuplet>
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000018165466" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000163000213" dur="16" oct="3" pname="g" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000000924016691" n="49">
+                            <staff xml:id="staff-0000000722337749" n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note xml:id="note-0000000475692573" dots="1" dur="8" oct="3" pname="c" accid.ges="s" />
+                                        <note xml:id="note-0000000089131372" dur="16" oct="3" pname="d" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000000436966555" dots="1" dur="8" oct="3" pname="e" accid.ges="s" />
+                                        <note xml:id="note-0000000958915602" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000001420598158" dots="1" dur="8" oct="3" pname="g" accid.ges="s" />
+                                        <note xml:id="note-0000000860637944" dur="16" oct="3" pname="e" accid.ges="s" />
+                                    </beam>
+                                    <beam>
+                                        <note xml:id="note-0000002007151947" dots="1" dur="8" oct="3" pname="a" accid.ges="s" />
+                                        <note xml:id="note-0000000640368958" dur="16" oct="3" pname="f" accid.ges="s" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure xml:id="measure-0000001975975990" right="rptend" n="50">
+                            <staff xml:id="staff-0000000354552036" n="1">
+                                <layer n="1">
+                                    <note xml:id="note-0000001790422992" dur="4" oct="3" pname="g" accid.ges="s" />
+                                    <note xml:id="note-0000000411154624" dur="4" oct="2" pname="g" accid.ges="s" />
+                                    <note xml:id="note-0000000098253069" dur="4" oct="3" pname="c" accid.ges="s" />
+                                    <rest xml:id="rest-0000002090582923" dur="4" />
+                                </layer>
+                            </staff>
+                        </measure>
+                    </section>
                 </score>
             </mdiv>
         </body>

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1241,6 +1241,13 @@
                                     <f>6</f>
                                 </fb>
                             </harm>
+                            <supplied resp="#rettinghaus">
+                                <harm place="above" staff="1" tstamp="3">
+                                    <fb>
+                                        <f>6</f>
+                                    </fb>
+                                </harm>
+                            </supplied>
                         </measure>
                         <measure xml:id="measure-0000000493740974" n="36">
                             <staff xml:id="staff-0000000189812959" n="1">
@@ -1521,7 +1528,9 @@
                                 <layer n="1">
                                     <note xml:id="note-0000002067369048" dur="4" oct="3" pname="a" accid.ges="f" />
                                     <note xml:id="note-0000001694250206" dur="4" oct="2" pname="a" accid.ges="f" />
-                                    <rest xml:id="rest-0000001170724136" dur="4" />
+                                    <supplied resp="#pfeffer" corresp="#rest-0000000055185116">
+                                        <rest xml:id="rest-0000001170724136" dur="4" />
+                                    </supplied>
                                     <beam>
                                         <note xml:id="note-0000002097349952" dots="1" dur="8" oct="4" pname="d" accid.ges="f" />
                                         <note xml:id="note-0000001595936764" dur="16" oct="3" pname="d" accid.ges="f" />

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -1528,10 +1528,6 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place="above" staff="1" tstamp="2">
-                                <fb>
-                                </fb>
-                            </harm>
                         </measure>
                         <measure xml:id="measure-0000001968799557" n="44">
                             <staff xml:id="staff-0000001912242454" n="1">

--- a/data/24/mattheson/score.mei
+++ b/data/24/mattheson/score.mei
@@ -101,22 +101,22 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -150,19 +150,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -196,11 +196,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -236,11 +236,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -256,21 +256,21 @@
                                     <note xml:id="note-0000000397966656" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                                 <f>5</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                                 <f>5</f>
@@ -298,11 +298,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -328,35 +328,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -382,19 +382,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
@@ -416,19 +416,19 @@
                                     <rest xml:id="rest-0000001100153303" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -459,27 +459,27 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>♭</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>♭</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
@@ -499,11 +499,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -532,11 +532,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -568,19 +568,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -612,11 +612,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -648,11 +648,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -678,11 +678,11 @@
                                     <note xml:id="note-0000001194843831" dur="4" oct="3" pname="a" accid.ges="f" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -699,13 +699,13 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                                 <f>5</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                                 <f>5</f>
@@ -733,27 +733,27 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -779,35 +779,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -836,27 +836,27 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -870,23 +870,23 @@
                                     <rest xml:id="rest-0000001740142267" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                                 <f>4</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                                 <f>4</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
 
                             </fb></harm>
@@ -918,11 +918,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -955,19 +955,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
@@ -999,11 +999,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1035,11 +1035,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1104,21 +1104,21 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
 
                                 <f>4</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
 
                                 <f>4</f>
@@ -1149,11 +1149,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1181,35 +1181,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
@@ -1235,35 +1235,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1289,35 +1289,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1338,19 +1338,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6⃥</f>
 
                             </fb></harm>
@@ -1376,19 +1376,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1405,31 +1405,31 @@
                                     <note xml:id="note-0000001236971930" dur="4" oct="3" pname="c" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                                 <f>5</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                                 <f>5</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>♮</f>
 
                             </fb></harm>
@@ -1451,11 +1451,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1487,19 +1487,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1521,7 +1521,7 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                                 <f>4</f>
@@ -1529,7 +1529,7 @@
                                 <f>2</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                                 <f>4</f>
@@ -1565,11 +1565,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1577,11 +1577,11 @@
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1648,11 +1648,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1680,19 +1680,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1729,7 +1729,7 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -1737,11 +1737,11 @@
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -1749,7 +1749,7 @@
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -1766,7 +1766,7 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
 
                             </fb></harm>
                         </measure>
@@ -1791,27 +1791,27 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -1838,35 +1838,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -1896,35 +1896,35 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="3.000000"><fb>
+                            <harm place='above' staff="1" tstamp="3"><fb>
                                 <f>7</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>7</f>
 
                             </fb></harm>
@@ -1950,19 +1950,19 @@
                                     <clef xml:id="clef-0000000352065921" shape="F" line="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -1993,11 +1993,11 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -2027,19 +2027,19 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>6</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="4.000000"><fb>
+                            <harm place='above' staff="1" tstamp="4"><fb>
                                 <f>6</f>
 
                             </fb></harm>
@@ -2053,23 +2053,23 @@
                                     <rest xml:id="rest-0000001944516741" dur="4" />
                                 </layer>
                             </staff>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                                 <f>4</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="1.000000"><fb>
+                            <harm place='above' staff="1" tstamp="1"><fb>
                                 <f>6</f>
 
                                 <f>4</f>
 
                             </fb></harm>
-                            <harm place='above' staff="1" tstamp="2.000000"><fb>
+                            <harm place='above' staff="1" tstamp="2"><fb>
                                 <f>3</f>
 
                             </fb></harm>


### PR DESCRIPTION
This is a first editorial run through on Probstück 24. 
Both variants are now in separate mdiv containers (NB: due to a [bug](https://github.com/rism-ch/verovio/issues/1290) the second one can't be rendered now).
There are some major differences in the figuered bass between these two. I had a first shot on supplying material, but there's still lot to do. 